### PR TITLE
Add branded contact page and navigation links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,830 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light" />
+  <title>CloseDose – Contact</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Contact CloseDose" />
+  <meta property="og:description" content="Reach the CloseDose team with questions, feedback, or partnership ideas." />
+  <meta property="og:image" content="images/og-2400.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Contact CloseDose" />
+  <meta name="twitter:description" content="Reach the CloseDose team with questions, feedback, or partnership ideas." />
+  <meta name="twitter:image" content="images/og-2400.png" />
+
+  <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="images/favicon-192.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/logo-teal.png" media="(prefers-color-scheme: light)">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/logo-dark.png" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#24a687" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0f2c2a" media="(prefers-color-scheme: dark)">
+
+  <style>
+    :root {
+      --teal-300: #3ec0ab;
+      --teal-400: #24a687;
+      --teal-500: #1f8f7b;
+      --teal-600: #123a37;
+      --ink-900: #0f2c2a;
+      --ink-700: #124643;
+      --bg: #f5f9f9;
+      --white: #ffffff;
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --card-border: 3px solid var(--ink-900);
+      --card-radius: 26px;
+      --shadow-card: 0 10px 32px rgba(18, 58, 55, 0.14);
+      --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.22);
+      --text-muted: rgba(15, 44, 42, 0.72);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg) url("images/light-bg.png") repeat;
+      background-size: 520px auto;
+      color: var(--ink-900);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .skip-link:focus {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 200;
+      width: auto;
+      height: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: var(--white);
+      border: 3px solid var(--ink-900);
+      box-shadow: var(--shadow-card);
+    }
+
+    .wrap {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      position: relative;
+      top: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(12px, 3vw, 32px);
+      padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+      margin-bottom: 0;
+    }
+
+    .header-wordmark {
+      display: block;
+      width: min(650px, 60vw);
+      max-width: 100%;
+      height: auto;
+    }
+
+    .menu-btn {
+      appearance: none;
+      border: var(--card-border);
+      border-radius: 50%;
+      background: var(--white);
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 12px;
+      font-size: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease,
+        background 0.12s ease,
+        width 0.18s ease,
+        padding 0.18s ease,
+        border-radius 0.18s ease;
+      position: fixed;
+      top: clamp(16px, 3vw, 32px);
+      right: clamp(18px, 5vw, 48px);
+      z-index: 1200;
+      width: 64px;
+      height: 64px;
+    }
+
+    .menu-btn:focus-visible {
+      outline: 3px solid var(--teal-400);
+      outline-offset: 4px;
+    }
+
+    .menu-btn .label {
+      display: none;
+    }
+
+    .menu-btn .hamburger {
+      width: 24px;
+      height: 16px;
+      position: relative;
+    }
+
+    .menu-btn .hamburger span {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink-900);
+      transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .menu-btn .hamburger span:nth-child(1) { top: 0; }
+    .menu-btn .hamburger span:nth-child(2) { top: calc(50% - 1.5px); }
+    .menu-btn .hamburger span:nth-child(3) { bottom: 0; }
+
+    main {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      padding: clamp(24px, 5vw, 60px) clamp(18px, 5vw, 48px) clamp(64px, 12vw, 120px);
+    }
+
+    .contact-page {
+      width: min(1160px, 100%);
+      display: grid;
+      gap: clamp(24px, 4vw, 36px);
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start;
+    }
+
+    .contact-card {
+      background: var(--card-bg);
+      border: var(--card-border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow-card);
+      padding: clamp(26px, 4vw, 42px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(20px, 2vw, 28px);
+    }
+
+    .contact-card h1 {
+      font-size: clamp(2rem, 3vw + 1rem, 2.8rem);
+      margin: 0;
+      line-height: 1.1;
+    }
+
+    .contact-card p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--text-muted);
+    }
+
+    .notice {
+      background: rgba(36, 166, 135, 0.12);
+      border-left: 4px solid var(--teal-400);
+      padding: 14px 16px;
+      border-radius: 12px;
+      font-size: 0.95rem;
+      color: var(--ink-700);
+    }
+
+    .notice a {
+      color: var(--teal-500);
+      text-decoration: underline;
+    }
+
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 22px;
+    }
+
+    .field-group {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .field-label {
+      font-size: 0.95rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+
+    .required-indicator {
+      color: #c0392b;
+    }
+
+    .input-shell {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .input-shell input,
+    .input-shell select,
+    .input-shell textarea {
+      appearance: none;
+      border: 2px solid rgba(18, 58, 55, 0.18);
+      border-radius: 14px;
+      padding: 14px 16px;
+      font: inherit;
+      background: var(--white);
+      color: inherit;
+      transition: border-color 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    .input-shell textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
+
+    .input-shell select {
+      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="%23123a37" stroke-width="1.8"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/%3E%3C/svg%3E');
+      background-repeat: no-repeat;
+      background-position: calc(100% - 16px) center;
+      background-size: 20px;
+      padding-right: 48px;
+    }
+
+    .input-shell input:focus-visible,
+    .input-shell select:focus-visible,
+    .input-shell textarea:focus-visible {
+      outline: none;
+      border-color: var(--teal-400);
+      box-shadow: 0 0 0 4px rgba(36, 166, 135, 0.18);
+    }
+
+    .input-shell.has-error input,
+    .input-shell.has-error select,
+    .input-shell.has-error textarea {
+      border-color: #d64545;
+      box-shadow: 0 0 0 4px rgba(214, 69, 69, 0.18);
+    }
+
+    .field-error {
+      margin: 4px 2px 0;
+      font-size: 0.85rem;
+      color: #a42828;
+      min-height: 1.2em;
+    }
+
+    .attachment-info {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 4px 0 0;
+    }
+
+    .file-input {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .file-input input[type="file"] {
+      border: 1px dashed rgba(18, 58, 55, 0.28);
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.72);
+      cursor: pointer;
+    }
+
+    .submit-row {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      flex-wrap: wrap;
+    }
+
+    .submit-btn {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      background: linear-gradient(135deg, var(--teal-400), var(--teal-500));
+      color: var(--white);
+      font-weight: 800;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      padding: 16px 30px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+    }
+
+    .submit-btn:hover,
+    .submit-btn:focus-visible {
+      transform: translateY(-1px);
+      filter: brightness(1.05);
+      outline: none;
+    }
+
+    .status-message {
+      font-size: 0.92rem;
+      color: var(--ink-700);
+    }
+
+    .contact-side {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 2.6vw, 24px);
+    }
+
+    .info-card {
+      background: rgba(255, 255, 255, 0.86);
+      border: 2px solid rgba(18, 58, 55, 0.16);
+      border-radius: 22px;
+      padding: clamp(20px, 3vw, 28px);
+      box-shadow: 0 18px 34px rgba(18, 58, 55, 0.12);
+      display: grid;
+      gap: 10px;
+    }
+
+    .info-card h2 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+
+    .info-card p {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--text-muted);
+    }
+
+    .info-card a {
+      color: var(--teal-500);
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .info-card a:hover,
+    .info-card a:focus-visible {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 1024px) {
+      .contact-page {
+        grid-template-columns: 1fr;
+      }
+
+      .menu-btn {
+        position: fixed;
+        bottom: clamp(18px, 6vw, 36px);
+        top: auto;
+      }
+    }
+
+    @media (max-width: 640px) {
+      main {
+        padding: 24px clamp(14px, 6vw, 24px) 80px;
+      }
+
+      .contact-card {
+        padding: clamp(22px, 6vw, 32px);
+      }
+
+      .menu-btn {
+        width: 56px;
+        height: 56px;
+      }
+    }
+
+    .menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 1400;
+      background: rgba(12, 31, 38, 0.52);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 32px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+    }
+
+    .menu-overlay.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .menu-panel {
+      background: var(--card-bg);
+      border-radius: 28px;
+      border: var(--card-border);
+      padding: clamp(24px, 4vw, 36px);
+      box-shadow: var(--shadow-card);
+      width: min(420px, 100%);
+      display: grid;
+      gap: 24px;
+    }
+
+    .menu-links {
+      display: grid;
+      gap: 12px;
+    }
+
+    .menu-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 14px 20px;
+      border-radius: 999px;
+      border: 2px solid rgba(18, 58, 55, 0.2);
+      font-weight: 700;
+      text-decoration: none;
+      color: var(--ink-900);
+      transition: background 0.18s ease, transform 0.18s ease, color 0.18s ease;
+    }
+
+    .menu-links a:hover,
+    .menu-links a:focus-visible {
+      background: rgba(36, 166, 135, 0.12);
+      color: var(--teal-600);
+      outline: none;
+    }
+
+    .menu-links a[aria-current="page"] {
+      background: linear-gradient(135deg, rgba(36, 166, 135, 0.18), rgba(36, 166, 135, 0.42));
+      border-color: rgba(36, 166, 135, 0.42);
+    }
+
+    .close-menu {
+      justify-self: start;
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      background: rgba(18, 58, 55, 0.12);
+      padding: 10px 18px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .close-menu:hover,
+    .close-menu:focus-visible {
+      background: rgba(18, 58, 55, 0.2);
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#contact-form">Skip to contact form</a>
+  <div class="wrap">
+    <header>
+      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
+        <span class="label">Menu</span>
+        <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
+      </button>
+    </header>
+
+    <main>
+      <div class="contact-page">
+        <section class="contact-card" aria-labelledby="contact-heading">
+          <div>
+            <h1 id="contact-heading">Contact CloseDose</h1>
+            <p>
+              We love hearing from families, clinicians, and partners who rely on CloseDose. Share your feedback, request new features,
+              or let us know how we can support your work.
+            </p>
+          </div>
+          <p class="notice">
+            Please do not include protected health information in your message. If you have an urgent medical concern, contact your pediatrician or call emergency services.
+          </p>
+          <form id="contact-form" method="post" action="https://formsubmit.co/contact@closedose.com" enctype="multipart/form-data" novalidate>
+            <div class="field-group">
+              <label class="field-label" for="name">Name <span class="required-indicator" aria-hidden="true">*</span></label>
+              <div class="input-shell" data-field="name">
+                <input type="text" id="name" name="name" autocomplete="name" placeholder="Enter your name" required aria-describedby="name-error" />
+                <p class="field-error" id="name-error" role="alert" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label class="field-label" for="email">Email address <span class="required-indicator" aria-hidden="true">*</span></label>
+              <div class="input-shell" data-field="email">
+                <input type="email" id="email" name="email" autocomplete="email" placeholder="you@example.com" required aria-describedby="email-error" />
+                <p class="field-error" id="email-error" role="alert" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label class="field-label" for="topic">How can we help? <span class="required-indicator" aria-hidden="true">*</span></label>
+              <div class="input-shell" data-field="topic">
+                <select id="topic" name="topic" required aria-describedby="topic-error">
+                  <option value="" disabled selected>Select a topic</option>
+                  <option value="general-question">General question</option>
+                  <option value="product-feedback">Product feedback</option>
+                  <option value="partnerships">Partnership inquiry</option>
+                  <option value="press">Press / media</option>
+                  <option value="technical-support">Technical support</option>
+                </select>
+                <p class="field-error" id="topic-error" role="alert" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label class="field-label" for="message">Comments <span class="required-indicator" aria-hidden="true">*</span></label>
+              <div class="input-shell" data-field="message">
+                <textarea id="message" name="message" placeholder="Share details that will help us respond" required aria-describedby="message-error"></textarea>
+                <p class="field-error" id="message-error" role="alert" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <span class="field-label">Attachment (optional)</span>
+              <div class="file-input input-shell" data-field="file">
+                <input type="file" id="attachment" name="attachment" accept=".jpg,.jpeg,.png,.gif,.pdf" aria-describedby="file-error" />
+                <p class="attachment-info">Accepted formats: JPG, PNG, GIF, or PDF up to 2 MB.</p>
+                <p class="field-error" id="file-error" role="alert" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="submit-row">
+              <button class="submit-btn" type="submit">Submit</button>
+              <p class="status-message" data-status-message aria-live="polite"></p>
+            </div>
+          </form>
+        </section>
+
+        <aside class="contact-side" aria-label="Additional ways to connect">
+          <article class="info-card">
+            <h2>Need quick answers?</h2>
+            <p>Visit our medication guides for product visuals, concentrations, and caregiver tips.</p>
+            <a href="medication-guides.html">Explore Medication Guides</a>
+          </article>
+
+          <article class="info-card">
+            <h2>Prefer email?</h2>
+            <p>Reach the CloseDose team directly at <a href="mailto:contact@closedose.com">contact@closedose.com</a>.</p>
+          </article>
+
+          <article class="info-card">
+            <h2>Partnerships &amp; media</h2>
+            <p>Interested in collaborating with CloseDose or sharing our story? Select "Partnership inquiry" or "Press / media" in the form and we’ll follow up soon.</p>
+          </article>
+        </aside>
+      </div>
+    </main>
+  </div>
+
+  <div class="menu-overlay" id="siteMenu" hidden>
+    <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">
+      <h2 id="menuHeading" class="visually-hidden">Site menu</h2>
+      <nav class="menu-links">
+        <a href="index.html">Calculator</a>
+        <a href="medication-guides.html">Medication Guides</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+      <button class="close-menu" type="button">Close</button>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const menuButton = document.querySelector('.menu-btn');
+      const overlay = document.getElementById('siteMenu');
+      if (!menuButton || !overlay) {
+        return;
+      }
+      const closeButton = overlay.querySelector('.close-menu');
+      if (!closeButton) {
+        return;
+      }
+      const focusableSelector = 'a, button, [tabindex]:not([tabindex="-1"])';
+
+      function openMenu() {
+        overlay.hidden = false;
+        requestAnimationFrame(() => overlay.classList.add('open'));
+        menuButton.setAttribute('aria-expanded', 'true');
+        menuButton.setAttribute('aria-label', 'Close menu');
+        const focusable = overlay.querySelectorAll(focusableSelector);
+        if (focusable.length) {
+          focusable[0].focus();
+        }
+      }
+
+      function closeMenu() {
+        overlay.classList.remove('open');
+        overlay.hidden = true;
+        menuButton.setAttribute('aria-expanded', 'false');
+        menuButton.setAttribute('aria-label', 'Open menu');
+        menuButton.focus();
+      }
+
+      menuButton.addEventListener('click', () => {
+        if (overlay.classList.contains('open')) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      closeButton.addEventListener('click', closeMenu);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeMenu();
+        }
+      });
+
+      overlay.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          return;
+        }
+        if (event.key !== 'Tab' || !overlay.classList.contains('open')) {
+          return;
+        }
+        const focusable = Array.from(overlay.querySelectorAll(focusableSelector));
+        if (!focusable.length) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      });
+
+      window.addEventListener('scroll', () => {
+        const atTop = window.scrollY <= 6;
+        menuButton.classList.toggle('is-expanded', atTop);
+      });
+    })();
+
+    (function () {
+      const form = document.getElementById('contact-form');
+      if (!form) {
+        return;
+      }
+
+      const statusEl = form.querySelector('[data-status-message]');
+      const fields = {
+        name: form.querySelector('[data-field="name"]'),
+        email: form.querySelector('[data-field="email"]'),
+        topic: form.querySelector('[data-field="topic"]'),
+        message: form.querySelector('[data-field="message"]'),
+        file: form.querySelector('[data-field="file"]'),
+      };
+
+      function setError(fieldKey, message) {
+        const field = fields[fieldKey];
+        if (!field) {
+          return;
+        }
+        const errorEl = field.querySelector('.field-error');
+        field.classList.toggle('has-error', Boolean(message));
+        if (errorEl) {
+          errorEl.textContent = message || '';
+        }
+      }
+
+      function validateName() {
+        const input = fields.name ? fields.name.querySelector('input') : null;
+        if (!input) return true;
+        const value = input.value.trim();
+        if (!value) {
+          setError('name', 'Name is required.');
+          return false;
+        }
+        setError('name');
+        return true;
+      }
+
+      function validateEmail() {
+        const input = fields.email ? fields.email.querySelector('input') : null;
+        if (!input) return true;
+        const value = input.value.trim();
+        if (!value) {
+          setError('email', 'Email is required.');
+          return false;
+        }
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(value)) {
+          setError('email', 'Enter a valid email address.');
+          return false;
+        }
+        setError('email');
+        return true;
+      }
+
+      function validateTopic() {
+        const select = fields.topic ? fields.topic.querySelector('select') : null;
+        if (!select) return true;
+        if (!select.value) {
+          setError('topic', 'Please choose a topic.');
+          return false;
+        }
+        setError('topic');
+        return true;
+      }
+
+      function validateMessage() {
+        const textarea = fields.message ? fields.message.querySelector('textarea') : null;
+        if (!textarea) return true;
+        const value = textarea.value.trim();
+        if (!value) {
+          setError('message', 'Comments are required.');
+          return false;
+        }
+        setError('message');
+        return true;
+      }
+
+      function validateFile() {
+        const input = fields.file ? fields.file.querySelector('input[type="file"]') : null;
+        if (!input || !input.files || !input.files[0]) {
+          setError('file');
+          return true;
+        }
+        const file = input.files[0];
+        const maxSize = 2 * 1024 * 1024;
+        const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'application/pdf'];
+        if (file.size > maxSize) {
+          setError('file', 'File must be 2 MB or smaller.');
+          return false;
+        }
+        if (!allowedTypes.includes(file.type)) {
+          setError('file', 'Unsupported file type. Please upload a JPG, PNG, GIF, or PDF.');
+          return false;
+        }
+        setError('file');
+        return true;
+      }
+
+      fields.name?.querySelector('input')?.addEventListener('blur', validateName);
+      fields.email?.querySelector('input')?.addEventListener('blur', validateEmail);
+      fields.topic?.querySelector('select')?.addEventListener('change', validateTopic);
+      fields.message?.querySelector('textarea')?.addEventListener('blur', validateMessage);
+      fields.file?.querySelector('input[type="file"]')?.addEventListener('change', validateFile);
+
+      form.addEventListener('submit', (event) => {
+        statusEl.textContent = '';
+        const isValid = [
+          validateName(),
+          validateEmail(),
+          validateTopic(),
+          validateMessage(),
+          validateFile(),
+        ].every(Boolean);
+
+        if (!isValid) {
+          event.preventDefault();
+          statusEl.textContent = 'Please resolve the highlighted fields before submitting.';
+          return;
+        }
+
+        statusEl.textContent = 'Thanks! We’ll respond as soon as we can.';
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1186,6 +1186,7 @@
       <nav class="menu-links">
         <a href="index.html" aria-current="page">Calculator</a>
         <a href="medication-guides.html">Medication Guides</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -849,6 +849,7 @@
       <nav class="menu-links">
         <a href="index.html">Calculator</a>
         <a href="medication-guides.html" aria-current="page">Medication Guides</a>
+        <a href="contact.html">Contact</a>
         <a href="#" aria-disabled="true">Translate</a>
         <a href="#" aria-disabled="true">Donate</a>
       </nav>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,4 +12,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://closedose.com/contact</loc>
+    <lastmod>2024-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a dedicated contact page with styled CloseDose form, contextual help, and client-side validation
- include the new page in the site menu overlays and sitemap so it is discoverable

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d65bd76e5083299dd9515479159a7a