### PR TITLE
Add localized calculator pages for Spanish, Portuguese, and French

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -1,0 +1,1324 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CloseDose – Calculadora de Dosis Pediátricas</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+  <link rel="apple-touch-icon" href="/logo-light.svg">
+  <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
+  <meta property="og:image" content="/images/OG-image.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <style>
+    :root {
+      --teal-400: #24a687;
+      --teal-500: #1f8f7b;
+      --teal-600: #123a37;
+      --ink-900: #0f2c2a;
+      --ink-700: #124643;
+      --bg: #f5f9f9;
+      --white: #ffffff;
+      --card-bg: rgba(255, 255, 255, 0.92);
+      --card-border: 3px solid var(--ink-900);
+      --card-radius: 26px;
+      --inner-radius: 18px;
+      --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
+      --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
+      --pill-max-width: 720px;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg) url("images/bg4k.png");
+      background-size: cover;
+      background-attachment: fixed;
+      color: var(--ink-900);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    select[hidden] {
+      display: none !important;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .skip-link:focus {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 200;
+      width: auto;
+      height: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: none;
+      border: 3px solid var(--ink-900);
+    }
+
+    .wrap {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      position: relative;
+      top: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(12px, 3vw, 32px);
+      padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+      margin-bottom: 0;
+    }
+
+
+    .header-wordmark {
+      display: block;
+      width: min(650px, 60vw);
+      max-width: 100%;
+      height: auto;
+      margin: 0 auto;
+    }
+
+
+    .menu-btn {
+      appearance: none;
+      border: var(--card-border);
+      border-radius: 50%;
+      background: var(--white);
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 12px;
+      font-size: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease,
+        background 0.12s ease,
+        width 0.18s ease,
+        padding 0.18s ease,
+        border-radius 0.18s ease;
+      position: fixed;
+      top: clamp(16px, 3vw, 32px);
+      right: clamp(18px, 5vw, 48px);
+      z-index: 1200;
+      width: 64px;
+      height: 64px;
+    }
+
+    .menu-btn .label {
+      display: none;
+    }
+
+    .menu-btn .hamburger {
+      width: 24px;
+      height: 16px;
+      position: relative;
+    }
+
+    .menu-btn .hamburger span {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink-900);
+      transition: background 0.12s ease;
+    }
+
+    .menu-btn .hamburger span:nth-child(1) { top: 0; }
+    .menu-btn .hamburger span:nth-child(2) { top: 6px; }
+    .menu-btn .hamburger span:nth-child(3) { top: 12px; }
+
+    .menu-btn:hover,
+    .menu-btn:focus-visible {
+      background: #f0faf6;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35);
+      outline: none;
+    }
+
+    .menu-btn:active {
+      transform: translateY(2px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25);
+    }
+
+    .menu-btn.is-expanded {
+      width: auto;
+      height: auto;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+    }
+
+    .menu-btn.is-expanded .label {
+      display: inline;
+    }
+
+    @media (max-width: 960px) {
+      header {
+        padding-inline: clamp(16px, 5vw, 32px);
+      }
+      .menu-btn {
+        top: auto;
+        bottom: clamp(20px, 6vw, 40px);
+        right: clamp(20px, 6vw, 40px);
+        box-shadow: 0 8px 0 rgba(15, 44, 42, 0.35);
+      }
+    }
+
+    @media (max-width: 640px) {
+      header {
+        background: transparent !important;
+        padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
+      }
+    }
+
+    main {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding: 0 clamp(18px, 5vw, 52px) clamp(48px, 8vw, 80px);
+      box-sizing: border-box;
+    }
+
+    .layout {
+      width: min(820px, 100%);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(32px, 6vw, 48px);
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: var(--card-border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow-card);
+      padding: clamp(24px, 4vw, 36px);
+      width: 100%;
+      max-width: min(760px, 100%);
+      margin: 0;
+    }
+
+    .card.card--calculator,
+    .donate-card,
+    .card--disclaimer {
+      align-self: stretch;
+    }
+
+    .donate-card {
+      background: linear-gradient(145deg, rgba(36, 166, 135, 0.94), rgba(18, 70, 67, 0.96));
+      color: #ffffff;
+      border-color: rgba(255, 255, 255, 0.65);
+      box-shadow: 0 10px 0 rgba(15, 44, 42, 0.42);
+      display: grid;
+      gap: clamp(16px, 3vw, 24px);
+      text-align: left;
+    }
+
+    .donate-card .donate-header {
+      display: grid;
+      gap: 8px;
+    }
+
+    .donate-card h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: inherit;
+    }
+
+    .donate-card .donate-subtitle {
+      margin: 0;
+      font-size: clamp(0.85rem, 2vw, 1rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .donate-card .donate-intro {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: rgba(255, 255, 255, 0.94);
+    }
+
+    .donate-card .donate-content {
+      display: grid;
+      gap: clamp(14px, 3vw, 20px);
+    }
+
+    .donate-card .donate-links {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    .donate-card .donate-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 18px;
+      border-radius: 16px;
+      border: 2px solid rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.12);
+      color: #ffffff;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+    }
+
+    .donate-card .donate-links a:hover,
+    .donate-card .donate-links a:focus-visible {
+      background: rgba(255, 255, 255, 0.28);
+      border-color: rgba(255, 255, 255, 0.85);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    .card--disclaimer {
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+      background: var(--card-bg);
+    }
+
+    .card--disclaimer > *:not(.trust-and-safety_background__A22kJ) {
+      position: relative;
+      z-index: 1;
+    }
+
+    .card--disclaimer .trust-and-safety_background__A22kJ {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: radial-gradient(circle at top right, rgba(36, 166, 135, 0.15), rgba(18, 70, 67, 0.65));
+      opacity: 0;
+      transform: scale(0.98);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
+      z-index: 0;
+      visibility: hidden;
+    }
+
+    .card--disclaimer:focus-visible {
+      outline: 3px solid rgba(18, 70, 67, 0.45);
+      outline-offset: 8px;
+    }
+
+    .card--disclaimer h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--teal-600);
+    }
+
+    .card--disclaimer .disclaimer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer .disclaimer-close {
+      appearance: none;
+      border: none;
+      background: rgba(18, 70, 67, 0.08);
+      color: var(--teal-600);
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 8px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      display: none;
+      white-space: nowrap;
+    }
+
+    .card--disclaimer .disclaimer-close:hover,
+    .card--disclaimer .disclaimer-close:focus-visible {
+      background: rgba(18, 70, 67, 0.16);
+      outline: none;
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.25);
+    }
+
+    .card--disclaimer .disclaimer-close:active {
+      transform: translateY(1px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.18);
+    }
+
+    .card--disclaimer .disclaimer-content {
+      display: grid;
+      gap: 14px;
+      text-align: left;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer p {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: var(--ink-900);
+    }
+
+    .card--disclaimer .disclaimer-updated {
+      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--ink-700);
+    }
+
+    .card--disclaimer .disclaimer-seek-care {
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    .card--disclaimer.is-expanded {
+      background: linear-gradient(140deg, rgba(15, 44, 42, 0.95), rgba(18, 70, 67, 0.98));
+      color: var(--white);
+      padding: clamp(32px, 6vw, 64px) clamp(24px, 6vw, 56px);
+      box-shadow: 0 18px 48px rgba(15, 44, 42, 0.35);
+      gap: clamp(24px, 4vw, 36px);
+    }
+
+    .card--disclaimer.is-expanded .trust-and-safety_background__A22kJ {
+      opacity: 1;
+      transform: scale(1);
+      visibility: visible;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header,
+    .card--disclaimer.is-expanded .disclaimer-content {
+      width: 100%;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header {
+      align-items: flex-start;
+    }
+
+    .card--disclaimer.is-expanded h2 {
+      color: #ffffff;
+      white-space: normal;
+      letter-spacing: 0.08em;
+      max-width: 100%;
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close {
+      display: inline-flex;
+      align-self: flex-start;
+      background: rgba(255, 255, 255, 0.14);
+      color: #ffffff;
+      box-shadow: 0 6px 20px rgba(15, 44, 42, 0.35);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:hover,
+    .card--disclaimer.is-expanded .disclaimer-close:focus-visible {
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 8px 24px rgba(15, 44, 42, 0.4);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:active {
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.3);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-updated {
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .card--disclaimer.is-expanded p {
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .card--calculator {
+      display: grid;
+      gap: clamp(20px, 3vw, 30px);
+    }
+
+    .calculator-header {
+      text-align: center;
+      display: grid;
+      gap: 8px;
+      justify-items: center;
+    }
+
+    .calculator-header .brand-name {
+      font-size: clamp(1.8rem, 3.8vw, 2.8rem);
+      font-weight: 900;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-family: "Gotham", "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+
+    form {
+      display: grid;
+      gap: clamp(20px, 3vw, 28px);
+    }
+
+    .form-group {
+      background: #f0faf6;
+      border: 3px solid var(--ink-900);
+      border-radius: var(--inner-radius);
+      padding: clamp(22px, 4vw, 30px);
+      display: grid;
+      gap: 18px;
+    }
+
+    .form-title {
+      font-weight: 800;
+      font-size: clamp(1.1rem, 2.8vw, 1.4rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .segmented {
+      display: grid;
+      gap: 16px;
+    }
+
+    .segmented-buttons {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .segmented button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: clamp(0.85rem, 2.6vw, 1.05rem);
+      letter-spacing: 0.05em;
+      padding: 14px 12px;
+      text-transform: uppercase;
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      cursor: pointer;
+    }
+
+    .segmented button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .segmented button:focus-visible,
+    .unit-toggle button:focus-visible,
+    .action button:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    .hello-box {
+      background: var(--white);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 18px;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    .unit-row {
+      display: grid;
+      gap: 16px;
+    }
+
+    .weight-input {
+      display: flex;
+      justify-content: center;
+    }
+
+    .weight-input input[type="number"] {
+      width: min(100%, 220px);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 14px 18px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-align: center;
+      font-family: "Nunito", sans-serif;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      background: var(--white);
+      color: var(--ink-900);
+      appearance: textfield;
+      -moz-appearance: textfield;
+    }
+
+    .weight-input input::-webkit-outer-spin-button,
+    .weight-input input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    .unit-toggle {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .unit-toggle button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: 1rem;
+      padding: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.55);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .unit-toggle button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 3px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .action button {
+      width: 100%;
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--teal-500);
+      color: var(--white);
+      font-weight: 900;
+      font-size: clamp(1.05rem, 3.4vw, 1.4rem);
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 18px;
+      box-shadow: 0 8px 0 rgba(15, 44, 42, 0.75);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .action button:hover:not(:disabled) {
+      background: var(--teal-400);
+    }
+
+    .action button:disabled {
+      background: #aacdc6;
+      cursor: not-allowed;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.5);
+    }
+
+    .action button:not(:disabled):active {
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .alert {
+      margin: 0;
+      border-radius: 18px;
+      border: 3px solid var(--ink-900);
+      padding: 18px 20px;
+      font-weight: 600;
+      line-height: 1.6;
+      text-align: left;
+      background: rgba(255, 255, 255, 0.96);
+      color: var(--teal-600);
+      box-shadow: var(--shadow-card);
+    }
+
+    .alert[hidden] {
+      display: none;
+    }
+
+    .alert:not([hidden]) {
+      display: block;
+    }
+
+    .alert--critical {
+      background: rgba(220, 38, 38, 0.16);
+      border-color: rgba(220, 38, 38, 0.45);
+      color: #8b1111;
+      box-shadow: 0 8px 0 rgba(139, 17, 17, 0.25);
+    }
+
+    #results {
+      text-align: left;
+      display: grid;
+      gap: 18px;
+    }
+
+    #results .result-weight {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      color: #6f807c;
+      background: rgba(18, 58, 55, 0.06);
+      border-radius: 18px;
+      border: 2px solid rgba(18, 58, 55, 0.18);
+      padding: 16px 18px;
+      line-height: 1.6;
+      letter-spacing: 0.01em;
+    }
+
+    #results .result-weight strong {
+      color: var(--ink-900);
+      display: inline-block;
+      margin-top: 6px;
+      font-size: 1.05rem;
+    }
+
+    #results .result-weight span {
+      display: inline-block;
+      font-size: 0.85rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(18, 58, 55, 0.8);
+    }
+
+    #results .result-group {
+      display: grid;
+      gap: 16px;
+    }
+
+    .result-card {
+      background: rgba(255, 255, 255, 0.96);
+      border: var(--card-border);
+      border-radius: 22px;
+      box-shadow: var(--shadow-card);
+      padding: 20px 22px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .result-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--teal-600);
+    }
+
+    .result-card p {
+      margin: 0;
+      color: var(--ink-900);
+      line-height: 1.5;
+    }
+
+    .result-card p strong {
+      color: var(--teal-600);
+    }
+
+    .result-card .dose-note {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--ink-700);
+    }
+
+    .warning-card {
+      border-radius: 20px;
+      padding: 16px 20px;
+      font-weight: 700;
+      border: 3px solid transparent;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.28);
+      background: rgba(31, 143, 123, 0.12);
+      color: var(--teal-600);
+      line-height: 1.5;
+    }
+
+    .warning-card strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .warning-card--orange {
+      background: rgba(255, 149, 0, 0.18);
+      border-color: rgba(255, 149, 0, 0.45);
+      color: #b35a00;
+    }
+
+    .warning-card--red-strong {
+      background: rgba(220, 38, 38, 0.2);
+      border-color: rgba(220, 38, 38, 0.55);
+      color: #8b1111;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .warning-card--red-strong strong {
+      margin-bottom: 8px;
+    }
+
+    .warning-card--red-soft {
+      background: rgba(220, 38, 38, 0.12);
+      border-color: rgba(220, 38, 38, 0.28);
+      color: #a12a2a;
+      font-style: italic;
+      font-weight: 600;
+      box-shadow: 0 4px 0 rgba(161, 42, 42, 0.2);
+    }
+
+    .warning-card--teal {
+      background: rgba(31, 143, 123, 0.16);
+      border-color: rgba(18, 58, 55, 0.45);
+      color: var(--teal-600);
+    }
+
+    footer {
+      padding: 24px clamp(18px, 5vw, 52px) 48px;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    footer small {
+      display: block;
+      max-width: 960px;
+      margin: 0 auto;
+      font-size: 0.78rem;
+      letter-spacing: 0.02em;
+      color: var(--teal-500);
+    }
+
+    /* Overlay menu */
+    .menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      background: rgba(245, 249, 249, 0.96);
+      backdrop-filter: blur(3px) saturate(1.02);
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.18s ease;
+    }
+
+    .menu-overlay.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .menu-panel {
+      width: min(420px, 92vw);
+      background: #fff;
+      border: var(--card-border);
+      border-radius: 24px;
+      box-shadow: 0 6px 0 var(--ink-900);
+      padding: 30px 28px;
+      transform: translateY(8px);
+      transition: transform 0.18s ease;
+      display: grid;
+      gap: 18px;
+    }
+
+    .menu-overlay.open .menu-panel {
+      transform: translateY(0);
+    }
+
+    .menu-links {
+      display: grid;
+      gap: 16px;
+    }
+
+    .menu-links a {
+      text-decoration: none;
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.06em;
+      text-align: center;
+      font-size: clamp(1.2rem, 2.8vw, 1.6rem);
+      padding: 10px 4px;
+      border-radius: 16px;
+      transition: background 0.12s ease, color 0.12s ease;
+    }
+
+    .menu-links a[aria-current="page"] {
+      background: #e4f4f0;
+      border: 2px solid var(--ink-900);
+    }
+
+    .close-menu {
+      justify-self: center;
+      padding: 10px 20px;
+      border-radius: 999px;
+      border: var(--card-border);
+      background: var(--teal-400);
+      color: #fff;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+    }
+
+    .close-menu:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    @media (max-width: 720px) {
+      .segmented-buttons {
+        grid-template-columns: 1fr;
+      }
+      .layout {
+        gap: 28px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#calculator">Saltar a la calculadora</a>
+  <div class="wrap">
+    <header>
+      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Abrir menú">
+        <span class="label">Menú</span>
+        <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
+      </button>
+    </header>
+
+    <main>
+      <div class="layout">
+        <section class="card card--calculator" aria-labelledby="calculator-title">
+          <div class="calculator-header">
+            <div class="brand-name" id="calculator-title">Calculadora de Medicamentos para Fiebre/Dolor</div>
+          </div>
+          <form id="calculator" novalidate>
+            <div class="form-group" aria-live="polite">
+              <div class="form-title">Edad del paciente</div>
+              <div class="segmented">
+                <div class="segmented-buttons" role="group" aria-label="Seleccionar edad del paciente">
+                  <button type="button" class="age-option" data-age="0-2" aria-pressed="false">0-2 meses</button>
+                  <button type="button" class="age-option" data-age="2-6" aria-pressed="false">2-6 meses</button>
+                  <button type="button" class="age-option" data-age="6+" aria-pressed="false">6+ meses</button>
+                </div>
+                <p class="hello-box">¡Bienvenido! Elige un grupo de edad para comenzar.</p>
+              </div>
+              <select id="age" name="age" aria-hidden="true" tabindex="-1" hidden>
+                <option value="">Seleccione la edad</option>
+                <option value="0-2">0-2 meses</option>
+                <option value="2-6">2-6 meses</option>
+                <option value="6+">6+ meses</option>
+              </select>
+              <p id="message" class="alert" hidden></p>
+            </div>
+
+            <div class="form-group">
+              <div class="form-title">Peso del paciente</div>
+              <div class="unit-row">
+                <div class="weight-input">
+                  <label for="weight" class="visually-hidden">Introducir peso</label>
+                  <input type="number" id="weight" name="weight" inputmode="decimal" placeholder="Introducir peso" min="0" step="0.1" />
+                </div>
+                <div class="unit-toggle" role="group" aria-label="Seleccionar unidad de peso">
+                  <button type="button" class="unit-option" data-unit="lbs" aria-pressed="true">lbs</button>
+                  <button type="button" class="unit-option" data-unit="kg" aria-pressed="false">kg</button>
+                </div>
+              </div>
+              <select id="weight-unit" name="weight-unit" aria-hidden="true" tabindex="-1" hidden>
+                <option value="lbs" selected>lbs</option>
+                <option value="kg">kg</option>
+              </select>
+            </div>
+
+            <div class="action">
+              <button type="submit">Calcular</button>
+            </div>
+            <div id="results" aria-live="polite"></div>
+          </form>
+        </section>
+        <section class="card donate-card" aria-labelledby="donate-heading">
+          <div class="donate-header">
+            <h2 id="donate-heading">¡Dona!</h2>
+            <p class="donate-subtitle">Ayuda a mantener CloseDose gratuito para las familias.</p>
+          </div>
+          <div class="donate-content">
+          <p class="donate-intro">
+            CloseDose sigue siendo un recurso gratuito gracias al apoyo de nuestra comunidad. Si te es posible, considera donar mediante una de las opciones a continuación; cada contribución nos ayuda a mantener y ampliar herramientas confiables de dosificación pediátrica.
+          </p>
+          <ul class="donate-links">
+            <li>
+              <a href="https://www.paypal.com/donate?business=donate%40closedose.com&currency_code=USD" target="_blank" rel="noopener">
+                Donar con PayPal
+              </a>
+            </li>
+            <li>
+              <a href="https://www.buymeacoffee.com/closedose" target="_blank" rel="noopener">
+                Invítanos un café
+              </a>
+            </li>
+            <li>
+              <a href="mailto:hello@closedose.com?subject=CloseDose%20Support" rel="noopener">
+                Conectar para patrocinios
+              </a>
+            </li>
+          </ul>
+        </div>
+        </section>
+        <section class="card card--disclaimer" aria-labelledby="disclaimer-heading" aria-expanded="false" tabindex="-1">
+          <div class="trust-and-safety_background__A22kJ" data-testid="value-prop" aria-hidden="true"></div>
+          <div class="disclaimer-header">
+            <h2 id="disclaimer-heading">Aviso legal</h2>
+            <button type="button" class="disclaimer-close" aria-label="Cerrar aviso legal">
+              Cerrar
+            </button>
+          </div>
+          <div class="disclaimer-content" hidden>
+          <p>
+            Esta calculadora es solo para apoyo educativo y no reemplaza la orientación de su pediatra o farmacéutico.
+            Confirme siempre la dosis antes de administrar un medicamento.
+          </p>
+          <p>
+            CloseDose se creó con la intención de proporcionar información de dosificación de medicamentos de venta libre comunes para niños generalmente sanos.
+          </p>
+          <p>
+            Si su hijo tiene entre 0 y 2 meses de edad, antecedentes médicos o quirúrgicos complejos, reacciones previas a medicamentos administrados, antecedentes de reacciones alérgicas o antecedentes personales o familiares significativos de enfermedad hepática o renal, consulte con su equipo médico antes de usar la calculadora de dosificación pediátrica de CloseDose.
+          </p>
+          <p class="disclaimer-seek-care"><strong>Cuándo buscar atención:</strong> ***</p>
+          <p class="disclaimer-updated">Actualizado 22.9.2025 • Nickolas Mancini, MD, MBA</p>
+        </div>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <div class="menu-overlay" id="siteMenu" hidden>
+    <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">
+      <h2 id="menuHeading" class="visually-hidden">Menú del sitio</h2>
+      <nav class="menu-links">
+        <a href="index.html" aria-current="page">Calculadora</a>
+        <a href="medication-guides.html">Guías de medicamentos</a>
+        <a href="about.html">Acerca de</a>
+        <a href="donations.html">Apoyar CloseDose</a>
+        <a href="contact.html">Contacto</a>
+      </nav>
+      <button class="close-menu" type="button">Cerrar</button>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+  <script>
+    (function () {
+      const menuButton = document.querySelector('.menu-btn');
+      const overlay = document.getElementById('siteMenu');
+      if (!menuButton || !overlay) {
+        return;
+      }
+      const closeButton = overlay.querySelector('.close-menu');
+      if (!closeButton) {
+        return;
+      }
+      const focusableSelector = 'a, button, [tabindex]:not([tabindex="-1"])';
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+
+      const updateMenuPresentation = () => {
+        if (!menuButton) {
+          return;
+        }
+        const atTop = window.scrollY <= 6;
+        menuButton.classList.toggle('is-expanded', atTop);
+      };
+
+      function openMenu() {
+        overlay.hidden = false;
+        requestAnimationFrame(() => overlay.classList.add('open'));
+        menuButton.setAttribute('aria-expanded', 'true');
+        menuButton.setAttribute('aria-label', 'Cerrar menú');
+        closeButton.focus();
+      }
+
+      function closeMenu() {
+        overlay.classList.remove('open');
+        overlay.hidden = true;
+        menuButton.setAttribute('aria-expanded', 'false');
+        menuButton.setAttribute('aria-label', 'Abrir menú');
+        menuButton.focus();
+      }
+
+      menuButton.addEventListener('click', () => {
+        if (overlay.classList.contains('open')) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      closeButton.addEventListener('click', closeMenu);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeMenu();
+        }
+      });
+
+      overlay.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          return;
+        }
+        if (event.key !== 'Tab' || !overlay.classList.contains('open')) {
+          return;
+        }
+        const focusable = Array.from(overlay.querySelectorAll(focusableSelector));
+        if (!focusable.length) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      });
+
+      updateMenuPresentation();
+      window.addEventListener('scroll', updateMenuPresentation, { passive: true });
+      window.addEventListener('resize', updateMenuPresentation);
+      if (typeof mobileQuery.addEventListener === 'function') {
+        mobileQuery.addEventListener('change', updateMenuPresentation);
+      } else if (typeof mobileQuery.addListener === 'function') {
+        mobileQuery.addListener(updateMenuPresentation);
+      }
+    })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const ageSelect = document.getElementById('age');
+      const ageButtons = document.querySelectorAll('.age-option');
+      const unitSelect = document.getElementById('weight-unit');
+      const unitButtons = document.querySelectorAll('.unit-option');
+      const calculateButton = document.querySelector('.action button');
+
+      function setAge(value) {
+        if (ageSelect) {
+          ageSelect.value = value;
+          ageSelect.dispatchEvent(new Event('change'));
+        }
+        updateAgeButtons();
+        if (typeof updateForm === 'function') {
+          updateForm();
+        }
+      }
+
+      function updateAgeButtons() {
+        const currentValue = ageSelect ? ageSelect.value : '';
+        ageButtons.forEach((button) => {
+          const isActive = button.dataset.age === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      ageButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.age || '';
+          setAge(value);
+        });
+      });
+
+      if (ageSelect) {
+        ageSelect.addEventListener('change', () => {
+          updateAgeButtons();
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      function setUnit(value) {
+        if (unitSelect) {
+          unitSelect.value = value;
+          unitSelect.dispatchEvent(new Event('change'));
+        }
+        const currentValue = unitSelect ? unitSelect.value : '';
+        unitButtons.forEach((button) => {
+          const isActive = button.dataset.unit === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      unitButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.unit || 'lbs';
+          setUnit(value);
+        });
+      });
+
+      if (unitSelect) {
+        unitSelect.addEventListener('change', () => {
+          const currentValue = unitSelect.value;
+          unitButtons.forEach((button) => {
+            const isActive = button.dataset.unit === currentValue;
+            button.setAttribute('aria-pressed', String(isActive));
+          });
+        });
+      }
+
+      if (calculateButton) {
+        calculateButton.addEventListener('click', () => {
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      updateAgeButtons();
+      if (unitSelect) {
+        setUnit(unitSelect.value || 'lbs');
+      }
+
+      const disclaimerCard = document.querySelector('.card--disclaimer');
+      const disclaimerContent = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-content') : null;
+      const disclaimerClose = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-close') : null;
+      const disclaimerOverlay = disclaimerCard
+        ? disclaimerCard.querySelector('.trust-and-safety_background__A22kJ')
+        : null;
+      const rootElement = document.documentElement;
+
+      let disclaimerDismissedManually = false;
+
+      const setDisclaimerState = (expanded, { manual = false } = {}) => {
+        if (!disclaimerCard) {
+          return;
+        }
+        disclaimerCard.classList.toggle('is-expanded', expanded);
+        disclaimerCard.setAttribute('aria-expanded', String(expanded));
+        if (disclaimerContent) {
+          disclaimerContent.hidden = !expanded;
+        }
+        if (disclaimerOverlay) {
+          disclaimerOverlay.setAttribute('aria-hidden', String(!expanded));
+        }
+        if (expanded) {
+          disclaimerDismissedManually = false;
+          if (disclaimerClose) {
+            requestAnimationFrame(() => {
+              if (disclaimerCard.classList.contains('is-expanded')) {
+                disclaimerClose.focus({ preventScroll: true });
+              }
+            });
+          }
+        } else {
+          const shouldRestoreFocus = manual || document.activeElement === disclaimerClose;
+          if (manual) {
+            disclaimerDismissedManually = true;
+          }
+          if (shouldRestoreFocus) {
+            requestAnimationFrame(() => {
+              disclaimerCard.focus({ preventScroll: true });
+            });
+          }
+        }
+      };
+
+      const updateDisclaimerState = () => {
+        if (!disclaimerCard) {
+          return;
+        }
+        const reachedBottom = window.innerHeight + window.scrollY >= rootElement.scrollHeight - 2;
+        const isExpanded = disclaimerCard.classList.contains('is-expanded');
+        if (reachedBottom && !isExpanded && !disclaimerDismissedManually) {
+          setDisclaimerState(true);
+        }
+        if (!reachedBottom && disclaimerDismissedManually) {
+          disclaimerDismissedManually = false;
+        }
+      };
+
+      updateDisclaimerState();
+      window.addEventListener('scroll', updateDisclaimerState, { passive: true });
+      window.addEventListener('resize', () => {
+        updateDisclaimerState();
+      });
+      window.addEventListener('load', () => {
+        updateDisclaimerState();
+      });
+
+      if (disclaimerClose) {
+        disclaimerClose.addEventListener('click', () => {
+          setDisclaimerState(false, { manual: true });
+        });
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && disclaimerCard && disclaimerCard.classList.contains('is-expanded')) {
+          setDisclaimerState(false, { manual: true });
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index-fr.html
+++ b/index-fr.html
@@ -1,0 +1,1324 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CloseDose – Calculateur de dosage pédiatrique</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+  <link rel="apple-touch-icon" href="/logo-light.svg">
+  <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
+  <meta property="og:image" content="/images/OG-image.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <style>
+    :root {
+      --teal-400: #24a687;
+      --teal-500: #1f8f7b;
+      --teal-600: #123a37;
+      --ink-900: #0f2c2a;
+      --ink-700: #124643;
+      --bg: #f5f9f9;
+      --white: #ffffff;
+      --card-bg: rgba(255, 255, 255, 0.92);
+      --card-border: 3px solid var(--ink-900);
+      --card-radius: 26px;
+      --inner-radius: 18px;
+      --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
+      --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
+      --pill-max-width: 720px;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg) url("images/bg4k.png");
+      background-size: cover;
+      background-attachment: fixed;
+      color: var(--ink-900);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    select[hidden] {
+      display: none !important;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .skip-link:focus {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 200;
+      width: auto;
+      height: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: none;
+      border: 3px solid var(--ink-900);
+    }
+
+    .wrap {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      position: relative;
+      top: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(12px, 3vw, 32px);
+      padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+      margin-bottom: 0;
+    }
+
+
+    .header-wordmark {
+      display: block;
+      width: min(650px, 60vw);
+      max-width: 100%;
+      height: auto;
+      margin: 0 auto;
+    }
+
+
+    .menu-btn {
+      appearance: none;
+      border: var(--card-border);
+      border-radius: 50%;
+      background: var(--white);
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 12px;
+      font-size: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease,
+        background 0.12s ease,
+        width 0.18s ease,
+        padding 0.18s ease,
+        border-radius 0.18s ease;
+      position: fixed;
+      top: clamp(16px, 3vw, 32px);
+      right: clamp(18px, 5vw, 48px);
+      z-index: 1200;
+      width: 64px;
+      height: 64px;
+    }
+
+    .menu-btn .label {
+      display: none;
+    }
+
+    .menu-btn .hamburger {
+      width: 24px;
+      height: 16px;
+      position: relative;
+    }
+
+    .menu-btn .hamburger span {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink-900);
+      transition: background 0.12s ease;
+    }
+
+    .menu-btn .hamburger span:nth-child(1) { top: 0; }
+    .menu-btn .hamburger span:nth-child(2) { top: 6px; }
+    .menu-btn .hamburger span:nth-child(3) { top: 12px; }
+
+    .menu-btn:hover,
+    .menu-btn:focus-visible {
+      background: #f0faf6;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35);
+      outline: none;
+    }
+
+    .menu-btn:active {
+      transform: translateY(2px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25);
+    }
+
+    .menu-btn.is-expanded {
+      width: auto;
+      height: auto;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+    }
+
+    .menu-btn.is-expanded .label {
+      display: inline;
+    }
+
+    @media (max-width: 960px) {
+      header {
+        padding-inline: clamp(16px, 5vw, 32px);
+      }
+      .menu-btn {
+        top: auto;
+        bottom: clamp(20px, 6vw, 40px);
+        right: clamp(20px, 6vw, 40px);
+        box-shadow: 0 8px 0 rgba(15, 44, 42, 0.35);
+      }
+    }
+
+    @media (max-width: 640px) {
+      header {
+        background: transparent !important;
+        padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
+      }
+    }
+
+    main {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding: 0 clamp(18px, 5vw, 52px) clamp(48px, 8vw, 80px);
+      box-sizing: border-box;
+    }
+
+    .layout {
+      width: min(820px, 100%);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(32px, 6vw, 48px);
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: var(--card-border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow-card);
+      padding: clamp(24px, 4vw, 36px);
+      width: 100%;
+      max-width: min(760px, 100%);
+      margin: 0;
+    }
+
+    .card.card--calculator,
+    .donate-card,
+    .card--disclaimer {
+      align-self: stretch;
+    }
+
+    .donate-card {
+      background: linear-gradient(145deg, rgba(36, 166, 135, 0.94), rgba(18, 70, 67, 0.96));
+      color: #ffffff;
+      border-color: rgba(255, 255, 255, 0.65);
+      box-shadow: 0 10px 0 rgba(15, 44, 42, 0.42);
+      display: grid;
+      gap: clamp(16px, 3vw, 24px);
+      text-align: left;
+    }
+
+    .donate-card .donate-header {
+      display: grid;
+      gap: 8px;
+    }
+
+    .donate-card h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: inherit;
+    }
+
+    .donate-card .donate-subtitle {
+      margin: 0;
+      font-size: clamp(0.85rem, 2vw, 1rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .donate-card .donate-intro {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: rgba(255, 255, 255, 0.94);
+    }
+
+    .donate-card .donate-content {
+      display: grid;
+      gap: clamp(14px, 3vw, 20px);
+    }
+
+    .donate-card .donate-links {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    .donate-card .donate-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 18px;
+      border-radius: 16px;
+      border: 2px solid rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.12);
+      color: #ffffff;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+    }
+
+    .donate-card .donate-links a:hover,
+    .donate-card .donate-links a:focus-visible {
+      background: rgba(255, 255, 255, 0.28);
+      border-color: rgba(255, 255, 255, 0.85);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    .card--disclaimer {
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+      background: var(--card-bg);
+    }
+
+    .card--disclaimer > *:not(.trust-and-safety_background__A22kJ) {
+      position: relative;
+      z-index: 1;
+    }
+
+    .card--disclaimer .trust-and-safety_background__A22kJ {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: radial-gradient(circle at top right, rgba(36, 166, 135, 0.15), rgba(18, 70, 67, 0.65));
+      opacity: 0;
+      transform: scale(0.98);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
+      z-index: 0;
+      visibility: hidden;
+    }
+
+    .card--disclaimer:focus-visible {
+      outline: 3px solid rgba(18, 70, 67, 0.45);
+      outline-offset: 8px;
+    }
+
+    .card--disclaimer h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--teal-600);
+    }
+
+    .card--disclaimer .disclaimer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer .disclaimer-close {
+      appearance: none;
+      border: none;
+      background: rgba(18, 70, 67, 0.08);
+      color: var(--teal-600);
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 8px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      display: none;
+      white-space: nowrap;
+    }
+
+    .card--disclaimer .disclaimer-close:hover,
+    .card--disclaimer .disclaimer-close:focus-visible {
+      background: rgba(18, 70, 67, 0.16);
+      outline: none;
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.25);
+    }
+
+    .card--disclaimer .disclaimer-close:active {
+      transform: translateY(1px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.18);
+    }
+
+    .card--disclaimer .disclaimer-content {
+      display: grid;
+      gap: 14px;
+      text-align: left;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer p {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: var(--ink-900);
+    }
+
+    .card--disclaimer .disclaimer-updated {
+      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--ink-700);
+    }
+
+    .card--disclaimer .disclaimer-seek-care {
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    .card--disclaimer.is-expanded {
+      background: linear-gradient(140deg, rgba(15, 44, 42, 0.95), rgba(18, 70, 67, 0.98));
+      color: var(--white);
+      padding: clamp(32px, 6vw, 64px) clamp(24px, 6vw, 56px);
+      box-shadow: 0 18px 48px rgba(15, 44, 42, 0.35);
+      gap: clamp(24px, 4vw, 36px);
+    }
+
+    .card--disclaimer.is-expanded .trust-and-safety_background__A22kJ {
+      opacity: 1;
+      transform: scale(1);
+      visibility: visible;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header,
+    .card--disclaimer.is-expanded .disclaimer-content {
+      width: 100%;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header {
+      align-items: flex-start;
+    }
+
+    .card--disclaimer.is-expanded h2 {
+      color: #ffffff;
+      white-space: normal;
+      letter-spacing: 0.08em;
+      max-width: 100%;
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close {
+      display: inline-flex;
+      align-self: flex-start;
+      background: rgba(255, 255, 255, 0.14);
+      color: #ffffff;
+      box-shadow: 0 6px 20px rgba(15, 44, 42, 0.35);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:hover,
+    .card--disclaimer.is-expanded .disclaimer-close:focus-visible {
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 8px 24px rgba(15, 44, 42, 0.4);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:active {
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.3);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-updated {
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .card--disclaimer.is-expanded p {
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .card--calculator {
+      display: grid;
+      gap: clamp(20px, 3vw, 30px);
+    }
+
+    .calculator-header {
+      text-align: center;
+      display: grid;
+      gap: 8px;
+      justify-items: center;
+    }
+
+    .calculator-header .brand-name {
+      font-size: clamp(1.8rem, 3.8vw, 2.8rem);
+      font-weight: 900;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-family: "Gotham", "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+
+    form {
+      display: grid;
+      gap: clamp(20px, 3vw, 28px);
+    }
+
+    .form-group {
+      background: #f0faf6;
+      border: 3px solid var(--ink-900);
+      border-radius: var(--inner-radius);
+      padding: clamp(22px, 4vw, 30px);
+      display: grid;
+      gap: 18px;
+    }
+
+    .form-title {
+      font-weight: 800;
+      font-size: clamp(1.1rem, 2.8vw, 1.4rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .segmented {
+      display: grid;
+      gap: 16px;
+    }
+
+    .segmented-buttons {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .segmented button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: clamp(0.85rem, 2.6vw, 1.05rem);
+      letter-spacing: 0.05em;
+      padding: 14px 12px;
+      text-transform: uppercase;
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      cursor: pointer;
+    }
+
+    .segmented button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .segmented button:focus-visible,
+    .unit-toggle button:focus-visible,
+    .action button:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    .hello-box {
+      background: var(--white);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 18px;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    .unit-row {
+      display: grid;
+      gap: 16px;
+    }
+
+    .weight-input {
+      display: flex;
+      justify-content: center;
+    }
+
+    .weight-input input[type="number"] {
+      width: min(100%, 220px);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 14px 18px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-align: center;
+      font-family: "Nunito", sans-serif;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      background: var(--white);
+      color: var(--ink-900);
+      appearance: textfield;
+      -moz-appearance: textfield;
+    }
+
+    .weight-input input::-webkit-outer-spin-button,
+    .weight-input input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    .unit-toggle {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .unit-toggle button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: 1rem;
+      padding: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.55);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .unit-toggle button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 3px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .action button {
+      width: 100%;
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--teal-500);
+      color: var(--white);
+      font-weight: 900;
+      font-size: clamp(1.05rem, 3.4vw, 1.4rem);
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 18px;
+      box-shadow: 0 8px 0 rgba(15, 44, 42, 0.75);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .action button:hover:not(:disabled) {
+      background: var(--teal-400);
+    }
+
+    .action button:disabled {
+      background: #aacdc6;
+      cursor: not-allowed;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.5);
+    }
+
+    .action button:not(:disabled):active {
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .alert {
+      margin: 0;
+      border-radius: 18px;
+      border: 3px solid var(--ink-900);
+      padding: 18px 20px;
+      font-weight: 600;
+      line-height: 1.6;
+      text-align: left;
+      background: rgba(255, 255, 255, 0.96);
+      color: var(--teal-600);
+      box-shadow: var(--shadow-card);
+    }
+
+    .alert[hidden] {
+      display: none;
+    }
+
+    .alert:not([hidden]) {
+      display: block;
+    }
+
+    .alert--critical {
+      background: rgba(220, 38, 38, 0.16);
+      border-color: rgba(220, 38, 38, 0.45);
+      color: #8b1111;
+      box-shadow: 0 8px 0 rgba(139, 17, 17, 0.25);
+    }
+
+    #results {
+      text-align: left;
+      display: grid;
+      gap: 18px;
+    }
+
+    #results .result-weight {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      color: #6f807c;
+      background: rgba(18, 58, 55, 0.06);
+      border-radius: 18px;
+      border: 2px solid rgba(18, 58, 55, 0.18);
+      padding: 16px 18px;
+      line-height: 1.6;
+      letter-spacing: 0.01em;
+    }
+
+    #results .result-weight strong {
+      color: var(--ink-900);
+      display: inline-block;
+      margin-top: 6px;
+      font-size: 1.05rem;
+    }
+
+    #results .result-weight span {
+      display: inline-block;
+      font-size: 0.85rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(18, 58, 55, 0.8);
+    }
+
+    #results .result-group {
+      display: grid;
+      gap: 16px;
+    }
+
+    .result-card {
+      background: rgba(255, 255, 255, 0.96);
+      border: var(--card-border);
+      border-radius: 22px;
+      box-shadow: var(--shadow-card);
+      padding: 20px 22px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .result-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--teal-600);
+    }
+
+    .result-card p {
+      margin: 0;
+      color: var(--ink-900);
+      line-height: 1.5;
+    }
+
+    .result-card p strong {
+      color: var(--teal-600);
+    }
+
+    .result-card .dose-note {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--ink-700);
+    }
+
+    .warning-card {
+      border-radius: 20px;
+      padding: 16px 20px;
+      font-weight: 700;
+      border: 3px solid transparent;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.28);
+      background: rgba(31, 143, 123, 0.12);
+      color: var(--teal-600);
+      line-height: 1.5;
+    }
+
+    .warning-card strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .warning-card--orange {
+      background: rgba(255, 149, 0, 0.18);
+      border-color: rgba(255, 149, 0, 0.45);
+      color: #b35a00;
+    }
+
+    .warning-card--red-strong {
+      background: rgba(220, 38, 38, 0.2);
+      border-color: rgba(220, 38, 38, 0.55);
+      color: #8b1111;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .warning-card--red-strong strong {
+      margin-bottom: 8px;
+    }
+
+    .warning-card--red-soft {
+      background: rgba(220, 38, 38, 0.12);
+      border-color: rgba(220, 38, 38, 0.28);
+      color: #a12a2a;
+      font-style: italic;
+      font-weight: 600;
+      box-shadow: 0 4px 0 rgba(161, 42, 42, 0.2);
+    }
+
+    .warning-card--teal {
+      background: rgba(31, 143, 123, 0.16);
+      border-color: rgba(18, 58, 55, 0.45);
+      color: var(--teal-600);
+    }
+
+    footer {
+      padding: 24px clamp(18px, 5vw, 52px) 48px;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    footer small {
+      display: block;
+      max-width: 960px;
+      margin: 0 auto;
+      font-size: 0.78rem;
+      letter-spacing: 0.02em;
+      color: var(--teal-500);
+    }
+
+    /* Overlay menu */
+    .menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      background: rgba(245, 249, 249, 0.96);
+      backdrop-filter: blur(3px) saturate(1.02);
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.18s ease;
+    }
+
+    .menu-overlay.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .menu-panel {
+      width: min(420px, 92vw);
+      background: #fff;
+      border: var(--card-border);
+      border-radius: 24px;
+      box-shadow: 0 6px 0 var(--ink-900);
+      padding: 30px 28px;
+      transform: translateY(8px);
+      transition: transform 0.18s ease;
+      display: grid;
+      gap: 18px;
+    }
+
+    .menu-overlay.open .menu-panel {
+      transform: translateY(0);
+    }
+
+    .menu-links {
+      display: grid;
+      gap: 16px;
+    }
+
+    .menu-links a {
+      text-decoration: none;
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.06em;
+      text-align: center;
+      font-size: clamp(1.2rem, 2.8vw, 1.6rem);
+      padding: 10px 4px;
+      border-radius: 16px;
+      transition: background 0.12s ease, color 0.12s ease;
+    }
+
+    .menu-links a[aria-current="page"] {
+      background: #e4f4f0;
+      border: 2px solid var(--ink-900);
+    }
+
+    .close-menu {
+      justify-self: center;
+      padding: 10px 20px;
+      border-radius: 999px;
+      border: var(--card-border);
+      background: var(--teal-400);
+      color: #fff;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+    }
+
+    .close-menu:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    @media (max-width: 720px) {
+      .segmented-buttons {
+        grid-template-columns: 1fr;
+      }
+      .layout {
+        gap: 28px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#calculator">Aller à la calculatrice</a>
+  <div class="wrap">
+    <header>
+      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Ouvrir le menu">
+        <span class="label">Menu</span>
+        <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
+      </button>
+    </header>
+
+    <main>
+      <div class="layout">
+        <section class="card card--calculator" aria-labelledby="calculator-title">
+          <div class="calculator-header">
+            <div class="brand-name" id="calculator-title">Calculatrice de médicaments pour fièvre/douleur</div>
+          </div>
+          <form id="calculator" novalidate>
+            <div class="form-group" aria-live="polite">
+              <div class="form-title">Âge du patient</div>
+              <div class="segmented">
+                <div class="segmented-buttons" role="group" aria-label="Sélectionner l'âge du patient">
+                  <button type="button" class="age-option" data-age="0-2" aria-pressed="false">0-2 mois</button>
+                  <button type="button" class="age-option" data-age="2-6" aria-pressed="false">2-6 mois</button>
+                  <button type="button" class="age-option" data-age="6+" aria-pressed="false">6+ mois</button>
+                </div>
+                <p class="hello-box">Bienvenue ! Choisissez un groupe d'âge pour commencer.</p>
+              </div>
+              <select id="age" name="age" aria-hidden="true" tabindex="-1" hidden>
+                <option value="">Sélectionnez l'âge</option>
+                <option value="0-2">0-2 mois</option>
+                <option value="2-6">2-6 mois</option>
+                <option value="6+">6+ mois</option>
+              </select>
+              <p id="message" class="alert" hidden></p>
+            </div>
+
+            <div class="form-group">
+              <div class="form-title">Poids du patient</div>
+              <div class="unit-row">
+                <div class="weight-input">
+                  <label for="weight" class="visually-hidden">Saisir le poids</label>
+                  <input type="number" id="weight" name="weight" inputmode="decimal" placeholder="Saisir le poids" min="0" step="0.1" />
+                </div>
+                <div class="unit-toggle" role="group" aria-label="Sélectionner l'unité de poids">
+                  <button type="button" class="unit-option" data-unit="lbs" aria-pressed="true">lbs</button>
+                  <button type="button" class="unit-option" data-unit="kg" aria-pressed="false">kg</button>
+                </div>
+              </div>
+              <select id="weight-unit" name="weight-unit" aria-hidden="true" tabindex="-1" hidden>
+                <option value="lbs" selected>lbs</option>
+                <option value="kg">kg</option>
+              </select>
+            </div>
+
+            <div class="action">
+              <button type="submit">Calculer</button>
+            </div>
+            <div id="results" aria-live="polite"></div>
+          </form>
+        </section>
+        <section class="card donate-card" aria-labelledby="donate-heading">
+          <div class="donate-header">
+            <h2 id="donate-heading">Faites un don !</h2>
+            <p class="donate-subtitle">Aidez à garder CloseDose gratuit pour les familles.</p>
+          </div>
+          <div class="donate-content">
+          <p class="donate-intro">
+            CloseDose reste une ressource gratuite grâce au soutien de notre communauté. Si vous le pouvez, envisagez de faire un don par l'une des options ci-dessous ; chaque contribution nous aide à maintenir et développer des outils fiables de dosage pédiatrique.
+          </p>
+          <ul class="donate-links">
+            <li>
+              <a href="https://www.paypal.com/donate?business=donate%40closedose.com&currency_code=USD" target="_blank" rel="noopener">
+                Faire un don avec PayPal
+              </a>
+            </li>
+            <li>
+              <a href="https://www.buymeacoffee.com/closedose" target="_blank" rel="noopener">
+                Offrez-nous un café
+              </a>
+            </li>
+            <li>
+              <a href="mailto:hello@closedose.com?subject=CloseDose%20Support" rel="noopener">
+                Contactez-nous pour des partenariats
+              </a>
+            </li>
+          </ul>
+        </div>
+        </section>
+        <section class="card card--disclaimer" aria-labelledby="disclaimer-heading" aria-expanded="false" tabindex="-1">
+          <div class="trust-and-safety_background__A22kJ" data-testid="value-prop" aria-hidden="true"></div>
+          <div class="disclaimer-header">
+            <h2 id="disclaimer-heading">Avertissement</h2>
+            <button type="button" class="disclaimer-close" aria-label="Fermer l'avertissement">
+              Fermer
+            </button>
+          </div>
+          <div class="disclaimer-content" hidden>
+          <p>
+            Cette calculatrice sert uniquement de soutien éducatif et ne remplace pas les conseils de votre pédiatre ou pharmacien.
+            Vérifiez toujours la posologie avant d’administrer un médicament.
+          </p>
+          <p>
+            CloseDose a été créé afin de fournir des informations de dosage sur les médicaments courants en vente libre pour les enfants généralement en bonne santé.
+          </p>
+          <p>
+            Si votre enfant a entre 0 et 2 mois, présente des antécédents médicaux ou chirurgicaux complexes, des réactions antérieures aux médicaments administrés, des antécédents de réactions allergiques ou un historique personnel ou familial significatif de maladie du foie ou des reins, consultez votre équipe médicale avant d'utiliser le calculateur de dosage pédiatrique CloseDose.
+          </p>
+          <p class="disclaimer-seek-care"><strong>Quand consulter :</strong> ***</p>
+          <p class="disclaimer-updated">Mis à jour le 22.9.2025 • Nickolas Mancini, MD, MBA</p>
+        </div>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <div class="menu-overlay" id="siteMenu" hidden>
+    <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">
+      <h2 id="menuHeading" class="visually-hidden">Menu du site</h2>
+      <nav class="menu-links">
+        <a href="index.html" aria-current="page">Calculatrice</a>
+        <a href="medication-guides.html">Guides de médicaments</a>
+        <a href="about.html">À propos</a>
+        <a href="donations.html">Soutenir CloseDose</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <button class="close-menu" type="button">Fermer</button>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+  <script>
+    (function () {
+      const menuButton = document.querySelector('.menu-btn');
+      const overlay = document.getElementById('siteMenu');
+      if (!menuButton || !overlay) {
+        return;
+      }
+      const closeButton = overlay.querySelector('.close-menu');
+      if (!closeButton) {
+        return;
+      }
+      const focusableSelector = 'a, button, [tabindex]:not([tabindex="-1"])';
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+
+      const updateMenuPresentation = () => {
+        if (!menuButton) {
+          return;
+        }
+        const atTop = window.scrollY <= 6;
+        menuButton.classList.toggle('is-expanded', atTop);
+      };
+
+      function openMenu() {
+        overlay.hidden = false;
+        requestAnimationFrame(() => overlay.classList.add('open'));
+        menuButton.setAttribute('aria-expanded', 'true');
+        menuButton.setAttribute('aria-label', 'Fermer le menu');
+        closeButton.focus();
+      }
+
+      function closeMenu() {
+        overlay.classList.remove('open');
+        overlay.hidden = true;
+        menuButton.setAttribute('aria-expanded', 'false');
+        menuButton.setAttribute('aria-label', 'Ouvrir le menu');
+        menuButton.focus();
+      }
+
+      menuButton.addEventListener('click', () => {
+        if (overlay.classList.contains('open')) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      closeButton.addEventListener('click', closeMenu);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeMenu();
+        }
+      });
+
+      overlay.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          return;
+        }
+        if (event.key !== 'Tab' || !overlay.classList.contains('open')) {
+          return;
+        }
+        const focusable = Array.from(overlay.querySelectorAll(focusableSelector));
+        if (!focusable.length) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      });
+
+      updateMenuPresentation();
+      window.addEventListener('scroll', updateMenuPresentation, { passive: true });
+      window.addEventListener('resize', updateMenuPresentation);
+      if (typeof mobileQuery.addEventListener === 'function') {
+        mobileQuery.addEventListener('change', updateMenuPresentation);
+      } else if (typeof mobileQuery.addListener === 'function') {
+        mobileQuery.addListener(updateMenuPresentation);
+      }
+    })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const ageSelect = document.getElementById('age');
+      const ageButtons = document.querySelectorAll('.age-option');
+      const unitSelect = document.getElementById('weight-unit');
+      const unitButtons = document.querySelectorAll('.unit-option');
+      const calculateButton = document.querySelector('.action button');
+
+      function setAge(value) {
+        if (ageSelect) {
+          ageSelect.value = value;
+          ageSelect.dispatchEvent(new Event('change'));
+        }
+        updateAgeButtons();
+        if (typeof updateForm === 'function') {
+          updateForm();
+        }
+      }
+
+      function updateAgeButtons() {
+        const currentValue = ageSelect ? ageSelect.value : '';
+        ageButtons.forEach((button) => {
+          const isActive = button.dataset.age === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      ageButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.age || '';
+          setAge(value);
+        });
+      });
+
+      if (ageSelect) {
+        ageSelect.addEventListener('change', () => {
+          updateAgeButtons();
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      function setUnit(value) {
+        if (unitSelect) {
+          unitSelect.value = value;
+          unitSelect.dispatchEvent(new Event('change'));
+        }
+        const currentValue = unitSelect ? unitSelect.value : '';
+        unitButtons.forEach((button) => {
+          const isActive = button.dataset.unit === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      unitButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.unit || 'lbs';
+          setUnit(value);
+        });
+      });
+
+      if (unitSelect) {
+        unitSelect.addEventListener('change', () => {
+          const currentValue = unitSelect.value;
+          unitButtons.forEach((button) => {
+            const isActive = button.dataset.unit === currentValue;
+            button.setAttribute('aria-pressed', String(isActive));
+          });
+        });
+      }
+
+      if (calculateButton) {
+        calculateButton.addEventListener('click', () => {
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      updateAgeButtons();
+      if (unitSelect) {
+        setUnit(unitSelect.value || 'lbs');
+      }
+
+      const disclaimerCard = document.querySelector('.card--disclaimer');
+      const disclaimerContent = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-content') : null;
+      const disclaimerClose = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-close') : null;
+      const disclaimerOverlay = disclaimerCard
+        ? disclaimerCard.querySelector('.trust-and-safety_background__A22kJ')
+        : null;
+      const rootElement = document.documentElement;
+
+      let disclaimerDismissedManually = false;
+
+      const setDisclaimerState = (expanded, { manual = false } = {}) => {
+        if (!disclaimerCard) {
+          return;
+        }
+        disclaimerCard.classList.toggle('is-expanded', expanded);
+        disclaimerCard.setAttribute('aria-expanded', String(expanded));
+        if (disclaimerContent) {
+          disclaimerContent.hidden = !expanded;
+        }
+        if (disclaimerOverlay) {
+          disclaimerOverlay.setAttribute('aria-hidden', String(!expanded));
+        }
+        if (expanded) {
+          disclaimerDismissedManually = false;
+          if (disclaimerClose) {
+            requestAnimationFrame(() => {
+              if (disclaimerCard.classList.contains('is-expanded')) {
+                disclaimerClose.focus({ preventScroll: true });
+              }
+            });
+          }
+        } else {
+          const shouldRestoreFocus = manual || document.activeElement === disclaimerClose;
+          if (manual) {
+            disclaimerDismissedManually = true;
+          }
+          if (shouldRestoreFocus) {
+            requestAnimationFrame(() => {
+              disclaimerCard.focus({ preventScroll: true });
+            });
+          }
+        }
+      };
+
+      const updateDisclaimerState = () => {
+        if (!disclaimerCard) {
+          return;
+        }
+        const reachedBottom = window.innerHeight + window.scrollY >= rootElement.scrollHeight - 2;
+        const isExpanded = disclaimerCard.classList.contains('is-expanded');
+        if (reachedBottom && !isExpanded && !disclaimerDismissedManually) {
+          setDisclaimerState(true);
+        }
+        if (!reachedBottom && disclaimerDismissedManually) {
+          disclaimerDismissedManually = false;
+        }
+      };
+
+      updateDisclaimerState();
+      window.addEventListener('scroll', updateDisclaimerState, { passive: true });
+      window.addEventListener('resize', () => {
+        updateDisclaimerState();
+      });
+      window.addEventListener('load', () => {
+        updateDisclaimerState();
+      });
+
+      if (disclaimerClose) {
+        disclaimerClose.addEventListener('click', () => {
+          setDisclaimerState(false, { manual: true });
+        });
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && disclaimerCard && disclaimerCard.classList.contains('is-expanded')) {
+          setDisclaimerState(false, { manual: true });
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index-pt.html
+++ b/index-pt.html
@@ -1,0 +1,1324 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CloseDose – Calculadora de Dosagem Pediátrica</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+  <link rel="apple-touch-icon" href="/logo-light.svg">
+  <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
+  <meta property="og:image" content="/images/OG-image.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <style>
+    :root {
+      --teal-400: #24a687;
+      --teal-500: #1f8f7b;
+      --teal-600: #123a37;
+      --ink-900: #0f2c2a;
+      --ink-700: #124643;
+      --bg: #f5f9f9;
+      --white: #ffffff;
+      --card-bg: rgba(255, 255, 255, 0.92);
+      --card-border: 3px solid var(--ink-900);
+      --card-radius: 26px;
+      --inner-radius: 18px;
+      --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
+      --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
+      --pill-max-width: 720px;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg) url("images/bg4k.png");
+      background-size: cover;
+      background-attachment: fixed;
+      color: var(--ink-900);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    select[hidden] {
+      display: none !important;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .skip-link:focus {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 200;
+      width: auto;
+      height: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: none;
+      border: 3px solid var(--ink-900);
+    }
+
+    .wrap {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      position: relative;
+      top: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(12px, 3vw, 32px);
+      padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+      margin-bottom: 0;
+    }
+
+
+    .header-wordmark {
+      display: block;
+      width: min(650px, 60vw);
+      max-width: 100%;
+      height: auto;
+      margin: 0 auto;
+    }
+
+
+    .menu-btn {
+      appearance: none;
+      border: var(--card-border);
+      border-radius: 50%;
+      background: var(--white);
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 12px;
+      font-size: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease,
+        background 0.12s ease,
+        width 0.18s ease,
+        padding 0.18s ease,
+        border-radius 0.18s ease;
+      position: fixed;
+      top: clamp(16px, 3vw, 32px);
+      right: clamp(18px, 5vw, 48px);
+      z-index: 1200;
+      width: 64px;
+      height: 64px;
+    }
+
+    .menu-btn .label {
+      display: none;
+    }
+
+    .menu-btn .hamburger {
+      width: 24px;
+      height: 16px;
+      position: relative;
+    }
+
+    .menu-btn .hamburger span {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink-900);
+      transition: background 0.12s ease;
+    }
+
+    .menu-btn .hamburger span:nth-child(1) { top: 0; }
+    .menu-btn .hamburger span:nth-child(2) { top: 6px; }
+    .menu-btn .hamburger span:nth-child(3) { top: 12px; }
+
+    .menu-btn:hover,
+    .menu-btn:focus-visible {
+      background: #f0faf6;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35);
+      outline: none;
+    }
+
+    .menu-btn:active {
+      transform: translateY(2px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25);
+    }
+
+    .menu-btn.is-expanded {
+      width: auto;
+      height: auto;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+    }
+
+    .menu-btn.is-expanded .label {
+      display: inline;
+    }
+
+    @media (max-width: 960px) {
+      header {
+        padding-inline: clamp(16px, 5vw, 32px);
+      }
+      .menu-btn {
+        top: auto;
+        bottom: clamp(20px, 6vw, 40px);
+        right: clamp(20px, 6vw, 40px);
+        box-shadow: 0 8px 0 rgba(15, 44, 42, 0.35);
+      }
+    }
+
+    @media (max-width: 640px) {
+      header {
+        background: transparent !important;
+        padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
+      }
+    }
+
+    main {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding: 0 clamp(18px, 5vw, 52px) clamp(48px, 8vw, 80px);
+      box-sizing: border-box;
+    }
+
+    .layout {
+      width: min(820px, 100%);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(32px, 6vw, 48px);
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: var(--card-border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow-card);
+      padding: clamp(24px, 4vw, 36px);
+      width: 100%;
+      max-width: min(760px, 100%);
+      margin: 0;
+    }
+
+    .card.card--calculator,
+    .donate-card,
+    .card--disclaimer {
+      align-self: stretch;
+    }
+
+    .donate-card {
+      background: linear-gradient(145deg, rgba(36, 166, 135, 0.94), rgba(18, 70, 67, 0.96));
+      color: #ffffff;
+      border-color: rgba(255, 255, 255, 0.65);
+      box-shadow: 0 10px 0 rgba(15, 44, 42, 0.42);
+      display: grid;
+      gap: clamp(16px, 3vw, 24px);
+      text-align: left;
+    }
+
+    .donate-card .donate-header {
+      display: grid;
+      gap: 8px;
+    }
+
+    .donate-card h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: inherit;
+    }
+
+    .donate-card .donate-subtitle {
+      margin: 0;
+      font-size: clamp(0.85rem, 2vw, 1rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .donate-card .donate-intro {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: rgba(255, 255, 255, 0.94);
+    }
+
+    .donate-card .donate-content {
+      display: grid;
+      gap: clamp(14px, 3vw, 20px);
+    }
+
+    .donate-card .donate-links {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    .donate-card .donate-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 18px;
+      border-radius: 16px;
+      border: 2px solid rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.12);
+      color: #ffffff;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+    }
+
+    .donate-card .donate-links a:hover,
+    .donate-card .donate-links a:focus-visible {
+      background: rgba(255, 255, 255, 0.28);
+      border-color: rgba(255, 255, 255, 0.85);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    .card--disclaimer {
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+      background: var(--card-bg);
+    }
+
+    .card--disclaimer > *:not(.trust-and-safety_background__A22kJ) {
+      position: relative;
+      z-index: 1;
+    }
+
+    .card--disclaimer .trust-and-safety_background__A22kJ {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: radial-gradient(circle at top right, rgba(36, 166, 135, 0.15), rgba(18, 70, 67, 0.65));
+      opacity: 0;
+      transform: scale(0.98);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
+      z-index: 0;
+      visibility: hidden;
+    }
+
+    .card--disclaimer:focus-visible {
+      outline: 3px solid rgba(18, 70, 67, 0.45);
+      outline-offset: 8px;
+    }
+
+    .card--disclaimer h2 {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.25rem);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--teal-600);
+    }
+
+    .card--disclaimer .disclaimer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer .disclaimer-close {
+      appearance: none;
+      border: none;
+      background: rgba(18, 70, 67, 0.08);
+      color: var(--teal-600);
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 8px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      display: none;
+      white-space: nowrap;
+    }
+
+    .card--disclaimer .disclaimer-close:hover,
+    .card--disclaimer .disclaimer-close:focus-visible {
+      background: rgba(18, 70, 67, 0.16);
+      outline: none;
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.25);
+    }
+
+    .card--disclaimer .disclaimer-close:active {
+      transform: translateY(1px);
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.18);
+    }
+
+    .card--disclaimer .disclaimer-content {
+      display: grid;
+      gap: 14px;
+      text-align: left;
+      width: min(960px, 100%);
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer p {
+      margin: 0;
+      font-size: 0.98rem;
+      line-height: 1.55;
+      color: var(--ink-900);
+    }
+
+    .card--disclaimer .disclaimer-updated {
+      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--ink-700);
+    }
+
+    .card--disclaimer .disclaimer-seek-care {
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    .card--disclaimer.is-expanded {
+      background: linear-gradient(140deg, rgba(15, 44, 42, 0.95), rgba(18, 70, 67, 0.98));
+      color: var(--white);
+      padding: clamp(32px, 6vw, 64px) clamp(24px, 6vw, 56px);
+      box-shadow: 0 18px 48px rgba(15, 44, 42, 0.35);
+      gap: clamp(24px, 4vw, 36px);
+    }
+
+    .card--disclaimer.is-expanded .trust-and-safety_background__A22kJ {
+      opacity: 1;
+      transform: scale(1);
+      visibility: visible;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header,
+    .card--disclaimer.is-expanded .disclaimer-content {
+      width: 100%;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-header {
+      align-items: flex-start;
+    }
+
+    .card--disclaimer.is-expanded h2 {
+      color: #ffffff;
+      white-space: normal;
+      letter-spacing: 0.08em;
+      max-width: 100%;
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close {
+      display: inline-flex;
+      align-self: flex-start;
+      background: rgba(255, 255, 255, 0.14);
+      color: #ffffff;
+      box-shadow: 0 6px 20px rgba(15, 44, 42, 0.35);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:hover,
+    .card--disclaimer.is-expanded .disclaimer-close:focus-visible {
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 8px 24px rgba(15, 44, 42, 0.4);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-close:active {
+      box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.3);
+    }
+
+    .card--disclaimer.is-expanded .disclaimer-updated {
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .card--disclaimer.is-expanded p {
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .card--calculator {
+      display: grid;
+      gap: clamp(20px, 3vw, 30px);
+    }
+
+    .calculator-header {
+      text-align: center;
+      display: grid;
+      gap: 8px;
+      justify-items: center;
+    }
+
+    .calculator-header .brand-name {
+      font-size: clamp(1.8rem, 3.8vw, 2.8rem);
+      font-weight: 900;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-family: "Gotham", "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+
+    form {
+      display: grid;
+      gap: clamp(20px, 3vw, 28px);
+    }
+
+    .form-group {
+      background: #f0faf6;
+      border: 3px solid var(--ink-900);
+      border-radius: var(--inner-radius);
+      padding: clamp(22px, 4vw, 30px);
+      display: grid;
+      gap: 18px;
+    }
+
+    .form-title {
+      font-weight: 800;
+      font-size: clamp(1.1rem, 2.8vw, 1.4rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .segmented {
+      display: grid;
+      gap: 16px;
+    }
+
+    .segmented-buttons {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .segmented button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: clamp(0.85rem, 2.6vw, 1.05rem);
+      letter-spacing: 0.05em;
+      padding: 14px 12px;
+      text-transform: uppercase;
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      cursor: pointer;
+    }
+
+    .segmented button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .segmented button:focus-visible,
+    .unit-toggle button:focus-visible,
+    .action button:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    .hello-box {
+      background: var(--white);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 18px;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    .unit-row {
+      display: grid;
+      gap: 16px;
+    }
+
+    .weight-input {
+      display: flex;
+      justify-content: center;
+    }
+
+    .weight-input input[type="number"] {
+      width: min(100%, 220px);
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      padding: 14px 18px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-align: center;
+      font-family: "Nunito", sans-serif;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      background: var(--white);
+      color: var(--ink-900);
+      appearance: textfield;
+      -moz-appearance: textfield;
+    }
+
+    .weight-input input::-webkit-outer-spin-button,
+    .weight-input input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    .unit-toggle {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .unit-toggle button {
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--white);
+      font-weight: 800;
+      font-size: 1rem;
+      padding: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.55);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .unit-toggle button[aria-pressed="true"] {
+      background: var(--teal-400);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 3px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .action button {
+      width: 100%;
+      border: 3px solid var(--ink-900);
+      border-radius: 18px;
+      background: var(--teal-500);
+      color: var(--white);
+      font-weight: 900;
+      font-size: clamp(1.05rem, 3.4vw, 1.4rem);
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 18px;
+      box-shadow: 0 8px 0 rgba(15, 44, 42, 0.75);
+      transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      cursor: pointer;
+    }
+
+    .action button:hover:not(:disabled) {
+      background: var(--teal-400);
+    }
+
+    .action button:disabled {
+      background: #aacdc6;
+      cursor: not-allowed;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.5);
+    }
+
+    .action button:not(:disabled):active {
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .alert {
+      margin: 0;
+      border-radius: 18px;
+      border: 3px solid var(--ink-900);
+      padding: 18px 20px;
+      font-weight: 600;
+      line-height: 1.6;
+      text-align: left;
+      background: rgba(255, 255, 255, 0.96);
+      color: var(--teal-600);
+      box-shadow: var(--shadow-card);
+    }
+
+    .alert[hidden] {
+      display: none;
+    }
+
+    .alert:not([hidden]) {
+      display: block;
+    }
+
+    .alert--critical {
+      background: rgba(220, 38, 38, 0.16);
+      border-color: rgba(220, 38, 38, 0.45);
+      color: #8b1111;
+      box-shadow: 0 8px 0 rgba(139, 17, 17, 0.25);
+    }
+
+    #results {
+      text-align: left;
+      display: grid;
+      gap: 18px;
+    }
+
+    #results .result-weight {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      color: #6f807c;
+      background: rgba(18, 58, 55, 0.06);
+      border-radius: 18px;
+      border: 2px solid rgba(18, 58, 55, 0.18);
+      padding: 16px 18px;
+      line-height: 1.6;
+      letter-spacing: 0.01em;
+    }
+
+    #results .result-weight strong {
+      color: var(--ink-900);
+      display: inline-block;
+      margin-top: 6px;
+      font-size: 1.05rem;
+    }
+
+    #results .result-weight span {
+      display: inline-block;
+      font-size: 0.85rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(18, 58, 55, 0.8);
+    }
+
+    #results .result-group {
+      display: grid;
+      gap: 16px;
+    }
+
+    .result-card {
+      background: rgba(255, 255, 255, 0.96);
+      border: var(--card-border);
+      border-radius: 22px;
+      box-shadow: var(--shadow-card);
+      padding: 20px 22px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .result-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--teal-600);
+    }
+
+    .result-card p {
+      margin: 0;
+      color: var(--ink-900);
+      line-height: 1.5;
+    }
+
+    .result-card p strong {
+      color: var(--teal-600);
+    }
+
+    .result-card .dose-note {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--ink-700);
+    }
+
+    .warning-card {
+      border-radius: 20px;
+      padding: 16px 20px;
+      font-weight: 700;
+      border: 3px solid transparent;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.28);
+      background: rgba(31, 143, 123, 0.12);
+      color: var(--teal-600);
+      line-height: 1.5;
+    }
+
+    .warning-card strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .warning-card--orange {
+      background: rgba(255, 149, 0, 0.18);
+      border-color: rgba(255, 149, 0, 0.45);
+      color: #b35a00;
+    }
+
+    .warning-card--red-strong {
+      background: rgba(220, 38, 38, 0.2);
+      border-color: rgba(220, 38, 38, 0.55);
+      color: #8b1111;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .warning-card--red-strong strong {
+      margin-bottom: 8px;
+    }
+
+    .warning-card--red-soft {
+      background: rgba(220, 38, 38, 0.12);
+      border-color: rgba(220, 38, 38, 0.28);
+      color: #a12a2a;
+      font-style: italic;
+      font-weight: 600;
+      box-shadow: 0 4px 0 rgba(161, 42, 42, 0.2);
+    }
+
+    .warning-card--teal {
+      background: rgba(31, 143, 123, 0.16);
+      border-color: rgba(18, 58, 55, 0.45);
+      color: var(--teal-600);
+    }
+
+    footer {
+      padding: 24px clamp(18px, 5vw, 52px) 48px;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      text-align: center;
+      color: var(--teal-600);
+    }
+
+    footer small {
+      display: block;
+      max-width: 960px;
+      margin: 0 auto;
+      font-size: 0.78rem;
+      letter-spacing: 0.02em;
+      color: var(--teal-500);
+    }
+
+    /* Overlay menu */
+    .menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      background: rgba(245, 249, 249, 0.96);
+      backdrop-filter: blur(3px) saturate(1.02);
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.18s ease;
+    }
+
+    .menu-overlay.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .menu-panel {
+      width: min(420px, 92vw);
+      background: #fff;
+      border: var(--card-border);
+      border-radius: 24px;
+      box-shadow: 0 6px 0 var(--ink-900);
+      padding: 30px 28px;
+      transform: translateY(8px);
+      transition: transform 0.18s ease;
+      display: grid;
+      gap: 18px;
+    }
+
+    .menu-overlay.open .menu-panel {
+      transform: translateY(0);
+    }
+
+    .menu-links {
+      display: grid;
+      gap: 16px;
+    }
+
+    .menu-links a {
+      text-decoration: none;
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.06em;
+      text-align: center;
+      font-size: clamp(1.2rem, 2.8vw, 1.6rem);
+      padding: 10px 4px;
+      border-radius: 16px;
+      transition: background 0.12s ease, color 0.12s ease;
+    }
+
+    .menu-links a[aria-current="page"] {
+      background: #e4f4f0;
+      border: 2px solid var(--ink-900);
+    }
+
+    .close-menu {
+      justify-self: center;
+      padding: 10px 20px;
+      border-radius: 999px;
+      border: var(--card-border);
+      background: var(--teal-400);
+      color: #fff;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+    }
+
+    .close-menu:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    @media (max-width: 720px) {
+      .segmented-buttons {
+        grid-template-columns: 1fr;
+      }
+      .layout {
+        gap: 28px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#calculator">Ir para a calculadora</a>
+  <div class="wrap">
+    <header>
+      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Abrir menu">
+        <span class="label">Menu</span>
+        <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
+      </button>
+    </header>
+
+    <main>
+      <div class="layout">
+        <section class="card card--calculator" aria-labelledby="calculator-title">
+          <div class="calculator-header">
+            <div class="brand-name" id="calculator-title">Calculadora de Medicamentos para Febre/Dor</div>
+          </div>
+          <form id="calculator" novalidate>
+            <div class="form-group" aria-live="polite">
+              <div class="form-title">Idade do paciente</div>
+              <div class="segmented">
+                <div class="segmented-buttons" role="group" aria-label="Selecionar idade do paciente">
+                  <button type="button" class="age-option" data-age="0-2" aria-pressed="false">0-2 meses</button>
+                  <button type="button" class="age-option" data-age="2-6" aria-pressed="false">2-6 meses</button>
+                  <button type="button" class="age-option" data-age="6+" aria-pressed="false">6+ meses</button>
+                </div>
+                <p class="hello-box">Bem-vindo! Escolha uma faixa etária para começar.</p>
+              </div>
+              <select id="age" name="age" aria-hidden="true" tabindex="-1" hidden>
+                <option value="">Selecione a idade</option>
+                <option value="0-2">0-2 meses</option>
+                <option value="2-6">2-6 meses</option>
+                <option value="6+">6+ meses</option>
+              </select>
+              <p id="message" class="alert" hidden></p>
+            </div>
+
+            <div class="form-group">
+              <div class="form-title">Peso do paciente</div>
+              <div class="unit-row">
+                <div class="weight-input">
+                  <label for="weight" class="visually-hidden">Digite o peso</label>
+                  <input type="number" id="weight" name="weight" inputmode="decimal" placeholder="Digite o peso" min="0" step="0.1" />
+                </div>
+                <div class="unit-toggle" role="group" aria-label="Selecionar unidade de peso">
+                  <button type="button" class="unit-option" data-unit="lbs" aria-pressed="true">lbs</button>
+                  <button type="button" class="unit-option" data-unit="kg" aria-pressed="false">kg</button>
+                </div>
+              </div>
+              <select id="weight-unit" name="weight-unit" aria-hidden="true" tabindex="-1" hidden>
+                <option value="lbs" selected>lbs</option>
+                <option value="kg">kg</option>
+              </select>
+            </div>
+
+            <div class="action">
+              <button type="submit">Calcular</button>
+            </div>
+            <div id="results" aria-live="polite"></div>
+          </form>
+        </section>
+        <section class="card donate-card" aria-labelledby="donate-heading">
+          <div class="donate-header">
+            <h2 id="donate-heading">Doe!</h2>
+            <p class="donate-subtitle">Ajude a manter o CloseDose gratuito para as famílias.</p>
+          </div>
+          <div class="donate-content">
+          <p class="donate-intro">
+            CloseDose continua sendo um recurso gratuito graças ao apoio da nossa comunidade. Se puder, considere fazer uma doação por meio de uma das opções abaixo; cada contribuição nos ajuda a manter e ampliar ferramentas confiáveis de dosagem pediátrica.
+          </p>
+          <ul class="donate-links">
+            <li>
+              <a href="https://www.paypal.com/donate?business=donate%40closedose.com&currency_code=USD" target="_blank" rel="noopener">
+                Doar com PayPal
+              </a>
+            </li>
+            <li>
+              <a href="https://www.buymeacoffee.com/closedose" target="_blank" rel="noopener">
+                Pague-nos um café
+              </a>
+            </li>
+            <li>
+              <a href="mailto:hello@closedose.com?subject=CloseDose%20Support" rel="noopener">
+                Conectar para patrocínios
+              </a>
+            </li>
+          </ul>
+        </div>
+        </section>
+        <section class="card card--disclaimer" aria-labelledby="disclaimer-heading" aria-expanded="false" tabindex="-1">
+          <div class="trust-and-safety_background__A22kJ" data-testid="value-prop" aria-hidden="true"></div>
+          <div class="disclaimer-header">
+            <h2 id="disclaimer-heading">Aviso</h2>
+            <button type="button" class="disclaimer-close" aria-label="Fechar aviso">
+              Fechar
+            </button>
+          </div>
+          <div class="disclaimer-content" hidden>
+          <p>
+            Esta calculadora serve apenas como apoio educacional e não substitui a orientação do seu pediatra ou farmacêutico.
+            Sempre confirme a dose antes de administrar o medicamento.
+          </p>
+          <p>
+            O CloseDose foi criado com a intenção de fornecer informações de dosagem de medicamentos comuns vendidos sem prescrição para crianças geralmente saudáveis.
+          </p>
+          <p>
+            Se o seu filho tiver entre 0 e 2 meses de idade, antecedentes médicos ou cirúrgicos complexos, reações anteriores a medicamentos administrados, histórico de reações alérgicas ou histórico pessoal ou familiar significativo de doença hepática ou renal, consulte sua equipe de saúde antes de usar a calculadora de dosagem pediátrica do CloseDose.
+          </p>
+          <p class="disclaimer-seek-care"><strong>Quando procurar atendimento:</strong> ***</p>
+          <p class="disclaimer-updated">Atualizado em 22.9.2025 • Nickolas Mancini, MD, MBA</p>
+        </div>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <div class="menu-overlay" id="siteMenu" hidden>
+    <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">
+      <h2 id="menuHeading" class="visually-hidden">Menu do site</h2>
+      <nav class="menu-links">
+        <a href="index.html" aria-current="page">Calculadora</a>
+        <a href="medication-guides.html">Guias de medicamentos</a>
+        <a href="about.html">Sobre</a>
+        <a href="donations.html">Apoie o CloseDose</a>
+        <a href="contact.html">Contato</a>
+      </nav>
+      <button class="close-menu" type="button">Fechar</button>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+  <script>
+    (function () {
+      const menuButton = document.querySelector('.menu-btn');
+      const overlay = document.getElementById('siteMenu');
+      if (!menuButton || !overlay) {
+        return;
+      }
+      const closeButton = overlay.querySelector('.close-menu');
+      if (!closeButton) {
+        return;
+      }
+      const focusableSelector = 'a, button, [tabindex]:not([tabindex="-1"])';
+      const mobileQuery = window.matchMedia('(max-width: 640px)');
+
+      const updateMenuPresentation = () => {
+        if (!menuButton) {
+          return;
+        }
+        const atTop = window.scrollY <= 6;
+        menuButton.classList.toggle('is-expanded', atTop);
+      };
+
+      function openMenu() {
+        overlay.hidden = false;
+        requestAnimationFrame(() => overlay.classList.add('open'));
+        menuButton.setAttribute('aria-expanded', 'true');
+        menuButton.setAttribute('aria-label', 'Fechar menu');
+        closeButton.focus();
+      }
+
+      function closeMenu() {
+        overlay.classList.remove('open');
+        overlay.hidden = true;
+        menuButton.setAttribute('aria-expanded', 'false');
+        menuButton.setAttribute('aria-label', 'Abrir menu');
+        menuButton.focus();
+      }
+
+      menuButton.addEventListener('click', () => {
+        if (overlay.classList.contains('open')) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      closeButton.addEventListener('click', closeMenu);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeMenu();
+        }
+      });
+
+      overlay.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          return;
+        }
+        if (event.key !== 'Tab' || !overlay.classList.contains('open')) {
+          return;
+        }
+        const focusable = Array.from(overlay.querySelectorAll(focusableSelector));
+        if (!focusable.length) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      });
+
+      updateMenuPresentation();
+      window.addEventListener('scroll', updateMenuPresentation, { passive: true });
+      window.addEventListener('resize', updateMenuPresentation);
+      if (typeof mobileQuery.addEventListener === 'function') {
+        mobileQuery.addEventListener('change', updateMenuPresentation);
+      } else if (typeof mobileQuery.addListener === 'function') {
+        mobileQuery.addListener(updateMenuPresentation);
+      }
+    })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const ageSelect = document.getElementById('age');
+      const ageButtons = document.querySelectorAll('.age-option');
+      const unitSelect = document.getElementById('weight-unit');
+      const unitButtons = document.querySelectorAll('.unit-option');
+      const calculateButton = document.querySelector('.action button');
+
+      function setAge(value) {
+        if (ageSelect) {
+          ageSelect.value = value;
+          ageSelect.dispatchEvent(new Event('change'));
+        }
+        updateAgeButtons();
+        if (typeof updateForm === 'function') {
+          updateForm();
+        }
+      }
+
+      function updateAgeButtons() {
+        const currentValue = ageSelect ? ageSelect.value : '';
+        ageButtons.forEach((button) => {
+          const isActive = button.dataset.age === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      ageButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.age || '';
+          setAge(value);
+        });
+      });
+
+      if (ageSelect) {
+        ageSelect.addEventListener('change', () => {
+          updateAgeButtons();
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      function setUnit(value) {
+        if (unitSelect) {
+          unitSelect.value = value;
+          unitSelect.dispatchEvent(new Event('change'));
+        }
+        const currentValue = unitSelect ? unitSelect.value : '';
+        unitButtons.forEach((button) => {
+          const isActive = button.dataset.unit === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      unitButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.unit || 'lbs';
+          setUnit(value);
+        });
+      });
+
+      if (unitSelect) {
+        unitSelect.addEventListener('change', () => {
+          const currentValue = unitSelect.value;
+          unitButtons.forEach((button) => {
+            const isActive = button.dataset.unit === currentValue;
+            button.setAttribute('aria-pressed', String(isActive));
+          });
+        });
+      }
+
+      if (calculateButton) {
+        calculateButton.addEventListener('click', () => {
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      updateAgeButtons();
+      if (unitSelect) {
+        setUnit(unitSelect.value || 'lbs');
+      }
+
+      const disclaimerCard = document.querySelector('.card--disclaimer');
+      const disclaimerContent = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-content') : null;
+      const disclaimerClose = disclaimerCard ? disclaimerCard.querySelector('.disclaimer-close') : null;
+      const disclaimerOverlay = disclaimerCard
+        ? disclaimerCard.querySelector('.trust-and-safety_background__A22kJ')
+        : null;
+      const rootElement = document.documentElement;
+
+      let disclaimerDismissedManually = false;
+
+      const setDisclaimerState = (expanded, { manual = false } = {}) => {
+        if (!disclaimerCard) {
+          return;
+        }
+        disclaimerCard.classList.toggle('is-expanded', expanded);
+        disclaimerCard.setAttribute('aria-expanded', String(expanded));
+        if (disclaimerContent) {
+          disclaimerContent.hidden = !expanded;
+        }
+        if (disclaimerOverlay) {
+          disclaimerOverlay.setAttribute('aria-hidden', String(!expanded));
+        }
+        if (expanded) {
+          disclaimerDismissedManually = false;
+          if (disclaimerClose) {
+            requestAnimationFrame(() => {
+              if (disclaimerCard.classList.contains('is-expanded')) {
+                disclaimerClose.focus({ preventScroll: true });
+              }
+            });
+          }
+        } else {
+          const shouldRestoreFocus = manual || document.activeElement === disclaimerClose;
+          if (manual) {
+            disclaimerDismissedManually = true;
+          }
+          if (shouldRestoreFocus) {
+            requestAnimationFrame(() => {
+              disclaimerCard.focus({ preventScroll: true });
+            });
+          }
+        }
+      };
+
+      const updateDisclaimerState = () => {
+        if (!disclaimerCard) {
+          return;
+        }
+        const reachedBottom = window.innerHeight + window.scrollY >= rootElement.scrollHeight - 2;
+        const isExpanded = disclaimerCard.classList.contains('is-expanded');
+        if (reachedBottom && !isExpanded && !disclaimerDismissedManually) {
+          setDisclaimerState(true);
+        }
+        if (!reachedBottom && disclaimerDismissedManually) {
+          disclaimerDismissedManually = false;
+        }
+      };
+
+      updateDisclaimerState();
+      window.addEventListener('scroll', updateDisclaimerState, { passive: true });
+      window.addEventListener('resize', () => {
+        updateDisclaimerState();
+      });
+      window.addEventListener('load', () => {
+        updateDisclaimerState();
+      });
+
+      if (disclaimerClose) {
+        disclaimerClose.addEventListener('click', () => {
+          setDisclaimerState(false, { manual: true });
+        });
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && disclaimerCard && disclaimerCard.classList.contains('is-expanded')) {
+          setDisclaimerState(false, { manual: true });
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add localized copies of the calculator homepage for Spanish, Portuguese, and French audiences
- translate visible interface, navigation, donation, and disclaimer text while preserving existing structure and scripts
- update accessibility labels so menus and dialogs announce the correct localized actions

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68da437b7b1483298d5f1a9a7eb0b7e7