### PR TITLE
Align menu toggle button heights

### DIFF
--- a/about.html
+++ b/about.html
@@ -152,8 +152,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn:focus-visible {

--- a/contact.html
+++ b/contact.html
@@ -157,8 +157,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn:focus-visible {
@@ -204,7 +204,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/donations.html
+++ b/donations.html
@@ -158,8 +158,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -208,7 +208,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/index-es.html
+++ b/index-es.html
@@ -146,8 +146,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -188,7 +188,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/index-fr.html
+++ b/index-fr.html
@@ -146,8 +146,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -188,7 +188,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/index-pt.html
+++ b/index-pt.html
@@ -146,8 +146,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -188,7 +188,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/index.html
+++ b/index.html
@@ -147,8 +147,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -189,7 +189,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -178,8 +178,8 @@
       top: clamp(16px, 3vw, 32px);
       right: clamp(18px, 5vw, 48px);
       z-index: 1200;
-      width: 64px;
-      height: 64px;
+      width: 56px;
+      height: 56px;
     }
 
     .menu-btn .label {
@@ -219,7 +219,7 @@
 
     .menu-btn.is-expanded {
       width: auto;
-      height: auto;
+      height: 56px;
       padding: 12px 20px;
       border-radius: 999px;
       font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- reduce the collapsed menu toggle diameter so the hamburger and expanded menu heights meet in the middle
- hold the expanded toggle state to the same height to smooth the transition between icon-only and labeled states

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68dd789cca208329be9199fe38560cfc