### PR TITLE
Update disclaimer page layout and content

### DIFF
--- a/legal/disclaimer.html
+++ b/legal/disclaimer.html
@@ -1,18 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Medical & Site Disclaimer • CloseDose</title>
+  <style>
+    :root{--teal:#24A687;--ink:#0B1F1A;--muted:#4A5A55;--bg:#fff;--border:#E8F2EF;--maxw:840px}
+    body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial;color:var(--ink);background:var(--bg);line-height:1.6}
+    header{padding:48px 20px 16px;text-align:center;border-bottom:1px solid var(--border);background:radial-gradient(1200px 200px at 50% -80px, rgba(36,166,135,0.08), transparent 70%)}
+    .brand{font-weight:800;letter-spacing:.2px;color:var(--teal);text-transform:uppercase;font-size:14px;margin-bottom:6px;display:inline-block}
+    h1{margin:6px 0 4px;font-size:clamp(26px,4vw,34px);line-height:1.15}
+    .meta{color:var(--muted);font-size:14px;margin-top:4px}
+    main{padding:28px 20px 120px;max-width:var(--maxw);margin:0 auto}
+    h2{font-size:clamp(18px,2.5vw,22px);margin:22px 0 8px}
+    .card{background:#fff;border:1px solid var(--border);border-radius:14px;padding:20px}
+    footer{border-top:1px solid var(--border)} .footer-inner{max-width:var(--maxw);margin:0 auto;padding:18px 20px 26px;display:flex;gap:12px;flex-wrap:wrap;justify-content:center;font-size:14px}
+    .footer-inner a{color:#4A5A55;text-decoration:none;border-bottom:1px dashed rgba(0,0,0,.15)} .footer-inner a:hover{color:#0B1F1A}
+    .watermark{pointer-events:none;position:fixed;right:-30px;bottom:-10px;z-index:1;opacity:.06;font-weight:900;font-size:120px;line-height:1;color:#24A687;transform:rotate(-12deg);letter-spacing:1.5px;user-select:none}
+    @media (prefers-color-scheme: dark){
+      body{background:#0c1211;color:#ebf4f1}
+      .card{background:#0f1716;border-color:#122320}
+      .footer-inner{background:#0f1716}
+      .footer-inner a{color:#9fb9b2}
+      .meta{color:#9fb9b2}
+    }
+  </style>
+</head>
+<body>
+<div class="watermark">CloseDose</div>
+<header>
+  <div class="brand">CloseDose</div>
+  <h1>Medical &amp; Site Disclaimer</h1>
+  <div class="meta">Effective Date: <strong>October 02, 2025</strong></div>
+</header>
 
-<!DOCTYPE html><html lang="en"><head>
-<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Medical & Site Disclaimer • CloseDose</title>
-<style>
-:root{--teal:#24A687;--dark:#123934;--text:#0f2b29;--white:#ffffff;}
-body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color:var(--text);line-height:1.6;}
-.header{background:linear-gradient(135deg,var(--dark),var(--teal));color:var(--white);padding:48px 20px;text-align:center;}
-.container{max-width:900px;margin:auto;padding:20px;}
-.card{background:#fff;border-radius:12px;padding:24px;box-shadow:0 4px 16px rgba(0,0,0,.05);margin-bottom:40px;}
-.footer{background:#fbfdfc;border-top:1px solid #e6eeeb;padding:20px;text-align:center;font-size:.9rem;}
-.footer a{color:var(--teal);text-decoration:none;margin:0 5px;}
-</style></head><body>
-<header class="header"><h1>Medical & Site Disclaimer</h1><p>Important safety information and limits of our tools</p><p><em>Effective October 03, 2025</em></p></header>
-<div class="container"><div class="card"><h2>General Information</h2><p>CloseDose is not a substitute for professional advice...</p></div></div>
-<footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/linking">Acceptable Use</a>
-</footer></body></html>
+<main>
+  <section class="card">
+    <h2>General Information Only</h2>
+    <p>
+      CloseDose provides general educational information and weight-based dose calculators for acetaminophen and ibuprofen. The information is not a substitute for professional medical advice, diagnosis, or treatment.
+    </p>
+
+    <h2>Emergency &amp; Return Precautions</h2>
+    <p>
+      If you suspect an overdose, severe reaction, or your child appears very ill, call your local emergency number or poison control immediately. Always follow medication labels and instructions from your clinician.
+    </p>
+
+    <h2>Dosing Assumptions</h2>
+    <p>
+      Output is based on user-entered weight and typical pediatric dosing ranges. Concentrations vary by product and manufacturer; verify the concentration and formulation you have on hand.
+    </p>
+
+    <h2>No Establishment of Provider-Patient Relationship</h2>
+    <p>
+      Using the Services of CloseDose or any affiliated website does not create a provider-patient relationship with CloseDose or its contributors. Use of CloseDose tools is not a suitable alternative for establishment with a professional medical provider or professional medical care. CloseDose provides weight-based dosing guidance for over-the-counter medications and provides general educational information on over-the-counter medications. Medication dosing should be directed under the supervision of a medical professional and CloseDose is not a substitute for professional medical advice, diagnosis, or treatment.
+    </p>
+
+    <h2>No Warranties</h2>
+    <p>
+      The Services are provided “as is” without warranties of any kind. Use at your own risk and confirm information with a licensed professional.
+    </p>
+
+    <h2>Contact</h2>
+    <p>Questions? Email <a href="mailto:support@closedose.com">support@closedose.com</a>.</p>
+  </section>
+</main>
+
+<footer>
+  <div class="footer-inner">
+    <a href="terms.html">Terms</a> •
+    <a href="privacy.html">Privacy</a> •
+    <a href="disclaimer.html">Disclaimer</a> •
+    <a href="dmca.html">DMCA</a> •
+    <a href="linking.html">Acceptable Use &amp; Linking</a>
+  </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the disclaimer page with the updated CloseDose-branded layout and styling
- update the disclaimer copy to match the latest messaging and navigation links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a1054730832990d40ce9ddf81df7