### PR TITLE
Fix wordmark asset reference without binary addition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1199,7 +1199,7 @@
   <a class="skip-link" href="#calculator-card">Skip to calculator</a>
   <div class="wrap">
     <header>
-      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <img src="images/logo/CloseDose%20Logo_2048-transparent.png" alt="CloseDose" class="header-wordmark" />
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>

--- a/widget/close-dose-calculator.js
+++ b/widget/close-dose-calculator.js
@@ -482,7 +482,7 @@
       }
 
       .cdcalc-age-option {
-        min-height: 60px;
+        min-height: 92px;
       }
     }
   `;


### PR DESCRIPTION
## Summary
- ensure the mobile calculator view keeps the 12+ age button the same height as the other options
- update the homepage wordmark to reference the existing high-resolution PNG asset so no new binary needs to be committed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a09281d4832989c5d8565f2fcdaa