### PR TITLE
Redesign medication guides and about page with polished UI

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -9,19 +8,21 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="stylesheet" href="global.css" />
-
   <title>CloseDose – About</title>
 </head>
 <body>
   <div class="wrap">
-    
+
     <header>
-      <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      <a href="index.html" class="header-link">
+        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
       </button>
     </header>
+
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
       <img src="cappy/assets/Cappy circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
@@ -29,87 +30,83 @@
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
       </div>
     </button>
+
     <main>
       <div class="layout layout--inline">
-        <section class="card hero-card">
+
+        <!-- Hero -->
+        <section class="card hero-about" aria-labelledby="about-heading">
           <div class="hero-highlight">Built by pediatric physicians</div>
-          <h1>CloseDose helps families make confident, safe dosing decisions.</h1>
-          <p>
-            We created CloseDose to demystify pediatric medication dosing with tools that feel trustworthy, accessible, and easy to use—no matter the hour or the device.
-          </p>
-          <div class="cta-links">
-            <a href="index.html">Use the Calculator</a>
-            <a href="medication-guides.html">Browse Medication Guides</a>
+          <h1 id="about-heading">CloseDose helps families make confident, safe dosing decisions.</h1>
+          <p>We created CloseDose to demystify pediatric medication dosing with tools that feel trustworthy, accessible, and easy to use — no matter the hour or the device.</p>
+          <div class="about-cta">
+            <a href="index.html" class="about-cta--primary">Use the Calculator</a>
+            <a href="medication-guides.html" class="about-cta--secondary">Browse Medication Guides</a>
           </div>
         </section>
 
-        <section class="card story-card">
-          <h2>Why CloseDose exists</h2>
+        <!-- Why CloseDose exists -->
+        <section class="card story-card" aria-labelledby="story-heading">
+          <h2 id="story-heading">Why CloseDose exists</h2>
           <p>
             Parents and caregivers told us that dosing over-the-counter medicines often feels overwhelming. Between varying bottle concentrations, fast-changing guidance, and countless online charts, it can be hard to know what information to trust.
           </p>
           <p>
-            CloseDose combines clinical expertise with thoughtful design so caregivers can quickly calculate accurate, age-appropriate doses and review the context behind each recommendation.
+            CloseDose combines clinical expertise with thoughtful design so caregivers can quickly calculate accurate, age-appropriate doses — and understand the reasoning behind each recommendation.
           </p>
         </section>
 
-        <section class="card feature-card-group">
-          <h2>CloseDose at a glance</h2>
+        <!-- Feature icon grid -->
+        <section class="card feature-card-group" aria-labelledby="features-heading">
+          <h2 id="features-heading">CloseDose at a glance</h2>
           <p class="feature-intro">Every tool is built to remove guesswork for families and clinicians alike.</p>
           <ul class="feature-grid">
             <li class="feature-item">
-              <img src="images/about_icons/age-and-weight.svg" alt="Chart icon showing age and weight inputs" />
+              <img src="images/about_icons/age-and-weight.svg" alt="" aria-hidden="true" />
               <span>Only the age and weight you already know are needed to calculate the right dose.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/fast-results.svg" alt="Lightning bolt icon representing fast results" />
+              <img src="images/about_icons/fast-results.svg" alt="" aria-hidden="true" />
               <span>Fast results with simple inputs so you can help a sick child without delay.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/no-login-required.svg" alt="Unlocked padlock icon showing no login is required" />
-              <span>No account or subscription—just open CloseDose when you need it.</span>
+              <img src="images/about_icons/no-login-required.svg" alt="" aria-hidden="true" />
+              <span>No account or subscription — open CloseDose the moment you need it.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/accessible-design.svg" alt="Accessible design icon with universal symbols" />
-              <span>Designed for accessibility with high contrast colors and multilingual support.</span>
+              <img src="images/about_icons/accessible-design.svg" alt="" aria-hidden="true" />
+              <span>Designed for accessibility with high-contrast colors and multilingual support.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/color-coded-warnings.svg" alt="Color-coded warning icon" />
-              <span>Color-coded care and dosing warnings update instantly based on your answers.</span>
+              <img src="images/about_icons/color-coded-warnings.svg" alt="" aria-hidden="true" />
+              <span>Color-coded care warnings update instantly based on your answers.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/individualized-dosing.svg" alt="Targeted dosing icon illustrating individualized results" />
-              <span>Individualized dosing recommendations—no ranges to interpret or math to redo.</span>
+              <img src="images/about_icons/individualized-dosing.svg" alt="" aria-hidden="true" />
+              <span>Individualized dosing recommendations — no ranges to interpret or math to redo.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/multi-device-support.svg" alt="Icon showing CloseDose on multiple devices" />
+              <img src="images/about_icons/multi-device-support.svg" alt="" aria-hidden="true" />
               <span>Available on phones, tablets, and desktops wherever families are caring.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/intuitive-layout.svg" alt="Smiling face icon representing an intuitive layout" />
+              <img src="images/about_icons/intuitive-layout.svg" alt="" aria-hidden="true" />
               <span>Intuitive layout and plain language make it easy for anyone to use.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/evidence-based.svg" alt="Checkmark badge icon representing evidence-based guidance" />
-              <span>Accurate, evidence-based information that reflects the latest pediatric guidance.</span>
+              <img src="images/about_icons/evidence-based.svg" alt="" aria-hidden="true" />
+              <span>Accurate, evidence-based guidance that reflects the latest pediatric recommendations.</span>
             </li>
             <li class="feature-item">
-              <img src="images/about_icons/physician-reviewed.svg" alt="Stethoscope icon representing physician review" />
+              <img src="images/about_icons/physician-reviewed.svg" alt="" aria-hidden="true" />
               <span>Created and continually reviewed by an actively practicing pediatric emergency physician.</span>
-            </li>
-            <li class="feature-item">
-              <img src="images/about_icons/fast-results.svg" alt="Fast results icon emphasizing quick answers" />
-              <span>Fast results when every minute counts, so caregivers can act without second-guessing.</span>
-            </li>
-            <li class="feature-item">
-              <img src="images/about_icons/peace-of-mind.svg" alt="Heart icon representing peace of mind" />
-              <span>Peace of mind for caregivers—the reassurance that dosing decisions are backed by experts.</span>
             </li>
           </ul>
         </section>
 
-        <section class="card values-card">
-          <h2>What guides our work</h2>
+        <!-- What guides our work -->
+        <section class="card values-card" aria-labelledby="values-heading">
+          <h2 id="values-heading">What guides our work</h2>
           <ul>
             <li><strong>Safety first.</strong> Every update is reviewed by pediatric physicians who actively care for children.</li>
             <li><strong>Clarity matters.</strong> We explain dosing in plain language, with visuals that support calm decisions in stressful moments.</li>
@@ -117,8 +114,9 @@
           </ul>
         </section>
 
-        <a class="card impact-card impact-card-link" href="donation.html">
-          <img src="images/piggyFINAL.svg" alt="Piggy bank icon with coins" />
+        <!-- Community support link -->
+        <a class="card impact-card" href="donations.html">
+          <img src="images/piggyFINAL.svg" alt="Piggy bank icon" />
           <div>
             <h2>Community supported</h2>
             <p>
@@ -127,21 +125,22 @@
           </div>
         </a>
 
-        <section class="card trust-card">
-          <h2>How we maintain trust</h2>
-          <p>
-            CloseDose follows strict safeguards before we share guidance with families.
-          </p>
+        <!-- How we maintain trust -->
+        <section class="card trust-card" aria-labelledby="trust-heading">
+          <h2 id="trust-heading">How we maintain trust</h2>
+          <p>CloseDose follows strict safeguards before we share guidance with families.</p>
           <ul class="trust-points">
-            <li>Medication data is sourced from trusted pediatric references and double-checked against manufacturer labeling.</li>
+            <li>Medication data is sourced from trusted pediatric references and double-checked against current manufacturer labeling.</li>
             <li>Review dates are displayed across the site so you always know when information was last validated.</li>
             <li>We actively collect feedback from clinicians, pharmacists, and caregivers to keep improving the experience.</li>
           </ul>
         </section>
-<section class="card card--disclaimer" role="button" tabindex="0" aria-expanded="false">
+
+        <!-- Disclaimer -->
+        <section class="card card--disclaimer" role="button" tabindex="0" aria-expanded="false">
           <div class="disclaimer-header">
             <span class="eyebrow">Disclaimer</span>
-            <h2>Medication Safety & Usage</h2>
+            <h2>Medication Safety &amp; Usage</h2>
             <p>Tap to read important safety information</p>
           </div>
           <div class="disclaimer-content" hidden>
@@ -154,10 +153,11 @@
             </ul>
           </div>
         </section>
+
       </div>
     </main>
   </div>
-  
+
   <footer class="cd-footer">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
     <nav class="cd-legal cd-legal--full">
@@ -191,7 +191,8 @@
       </form>
     </div>
   </div>
+
   <script src="global.js" defer></script>
-  
+
 </body>
 </html>

--- a/global.css
+++ b/global.css
@@ -626,3 +626,484 @@ main {
 .menu-links a:hover { transform: scale(1.1); color: var(--teal-400); }
 .menu-links a[aria-current="page"] { color: var(--teal-400); pointer-events: none; }
 .close-menu { appearance: none; background: var(--white); border: var(--card-border); border-radius: 999px; padding: 12px 32px; font-weight: 900; text-transform: uppercase; letter-spacing: 0.1em; cursor: pointer; box-shadow: var(--shadow-btn); }
+
+/* =============================================
+   MEDICATION GUIDES
+   ============================================= */
+
+/* Guide hero — transparent, white text */
+.guide-hero {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  text-align: center;
+  color: var(--white);
+  padding: clamp(8px, 2vw, 16px) 0 clamp(8px, 2vw, 12px);
+}
+
+.guide-hero h1 {
+  margin: 0 0 10px;
+  font-size: clamp(1.7rem, 2.2vw + 1rem, 2.8rem);
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  color: #ffffff;
+  text-shadow: 0 2px 18px rgba(0,0,0,0.35);
+}
+
+.guide-hero p {
+  margin: 0 auto;
+  max-width: 58ch;
+  font-size: clamp(1rem, 0.6vw + 0.85rem, 1.12rem);
+  line-height: 1.55;
+  color: rgba(255,255,255,0.84);
+}
+
+/* Medication article cards */
+.med-guide { color: var(--ink-900); }
+
+.med-guide__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px 16px;
+  margin-bottom: 20px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid rgba(15,44,42,0.1);
+}
+
+.med-guide__header-text h2 {
+  margin: 0 0 6px;
+  font-size: clamp(1.3rem, 1.5vw + 1rem, 1.85rem);
+  font-weight: 900;
+  line-height: 1.2;
+}
+
+.med-guide__header-text p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+/* Concentration badges */
+.conc-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 4px 11px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.conc-badge--ace {
+  background: rgba(255,192,56,0.18);
+  color: #6b4000;
+  border: 1px solid rgba(255,192,56,0.45);
+}
+
+.conc-badge--child {
+  background: rgba(56,130,255,0.12);
+  color: #1a3a80;
+  border: 1px solid rgba(56,130,255,0.35);
+}
+
+.conc-badge--infant {
+  background: rgba(160,56,255,0.1);
+  color: #4a1a7a;
+  border: 1px solid rgba(160,56,255,0.3);
+}
+
+/* Ibuprofen concentration tab switcher */
+.conc-switcher {
+  display: inline-flex;
+  gap: 5px;
+  padding: 5px;
+  background: rgba(15,44,42,0.07);
+  border-radius: 14px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  max-width: 100%;
+}
+
+.conc-tab {
+  appearance: none;
+  border: 2px solid transparent;
+  background: transparent;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 0.88rem;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  line-height: 1.2;
+}
+
+.conc-tab:hover { background: rgba(255,255,255,0.6); color: var(--ink-900); }
+
+.conc-tab.is-active {
+  background: white;
+  color: var(--ink-900);
+  box-shadow: 0 2px 10px rgba(15,44,42,0.14);
+}
+
+.conc-tab .conc-badge { font-size: 0.67rem; pointer-events: none; }
+
+/* Concentration panels (hidden/shown by JS) */
+.conc-panel { display: none; }
+.conc-panel.is-active { display: block; animation: slam-in 0.3s ease both; }
+
+/* Product section */
+.product-section { margin-bottom: 28px; }
+
+.product-section__label {
+  font-size: 0.69rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.product-section__label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(15,44,42,0.1);
+}
+
+/* CSS scroll-snap product strip */
+.product-strip {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  padding: 4px 2px 14px;
+  cursor: grab;
+}
+
+.product-strip::-webkit-scrollbar { display: none; }
+.product-strip.is-dragging { cursor: grabbing; scroll-snap-type: none; }
+
+.product-card {
+  flex: 0 0 clamp(148px, 37vw, 200px);
+  scroll-snap-align: start;
+  background: rgba(255,255,255,0.75);
+  border: 1px solid rgba(15,44,42,0.1);
+  border-radius: 14px;
+  padding: 14px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  text-align: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.product-card:hover { transform: translateY(-2px); box-shadow: 0 8px 20px rgba(15,44,42,0.12); }
+
+.product-card__img-wrap {
+  width: 100%;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border-radius: 10px;
+  overflow: hidden;
+  padding: 6px;
+}
+
+.product-card__img {
+  max-width: 100%;
+  max-height: 100%;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.product-card__name {
+  font-size: 0.79rem;
+  font-weight: 700;
+  color: var(--ink-900);
+  line-height: 1.3;
+  margin: 0;
+}
+
+/* Alternate formulation grid (chewables, suppositories, etc.) */
+.formulation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+  margin-bottom: 28px;
+}
+
+.formulation-card {
+  background: rgba(255,255,255,0.6);
+  border: 1px solid rgba(15,44,42,0.1);
+  border-radius: 12px;
+  padding: 16px 10px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+}
+
+.formulation-card__emoji { font-size: 2.2rem; line-height: 1; }
+.formulation-card__name { font-size: 0.82rem; font-weight: 700; color: var(--ink-900); margin: 0; line-height: 1.3; }
+.formulation-card__dose { font-size: 0.71rem; color: var(--text-muted); margin: 0; }
+
+/* Safety quick-reference card */
+.safety-card {
+  background: rgba(36,166,135,0.07);
+  border: 1px solid rgba(36,166,135,0.22);
+  border-radius: 14px;
+  padding: 16px 20px;
+  margin-top: 8px;
+}
+
+.safety-card__title {
+  font-size: 0.69rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--teal-500);
+  margin: 0 0 12px;
+}
+
+.safety-card ul { margin: 0; padding: 0; list-style: none; display: grid; gap: 8px; }
+
+.safety-card li {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--ink-900);
+}
+
+.safety-card li::before {
+  content: '✓';
+  color: var(--teal-400);
+  font-weight: 900;
+  font-size: 0.88rem;
+  flex-shrink: 0;
+  margin-top: 0.05em;
+}
+
+/* Inline warning note */
+.med-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: rgba(220,50,50,0.06);
+  border: 1px solid rgba(220,50,50,0.2);
+  border-radius: 10px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  font-size: 0.88rem;
+  color: #6a1111;
+  line-height: 1.45;
+}
+
+.med-warning::before { content: '⚠'; font-size: 1rem; flex-shrink: 0; margin-top: 0.05em; }
+
+@media (max-width: 480px) {
+  .product-card { flex: 0 0 clamp(140px, 54vw, 170px); }
+  .formulation-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+/* =============================================
+   ABOUT PAGE
+   ============================================= */
+
+/* Hero — uses .card for glass background, dark text */
+.hero-about { color: var(--ink-900); }
+
+.hero-about .hero-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--teal-600);
+  background: rgba(36,166,135,0.12);
+  border: 1px solid rgba(36,166,135,0.28);
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 14px;
+}
+
+.hero-about h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.4rem);
+  font-weight: 900;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+}
+
+.hero-about > p {
+  margin: 0 auto 20px;
+  max-width: 56ch;
+  font-size: clamp(1rem, 0.5vw + 0.9rem, 1.12rem);
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.about-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.about-cta a {
+  display: inline-flex;
+  align-items: center;
+  padding: 11px 22px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 0.88rem;
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.about-cta--primary {
+  background: var(--teal-400);
+  color: #fff !important;
+  box-shadow: 0 6px 20px rgba(36,166,135,0.3);
+}
+
+.about-cta--secondary {
+  background: rgba(15,44,42,0.07);
+  color: var(--ink-900) !important;
+  border: 1.5px solid rgba(15,44,42,0.18);
+}
+
+.about-cta a:hover { transform: translateY(-2px); }
+.about-cta--primary:hover { box-shadow: 0 10px 28px rgba(36,166,135,0.35); }
+
+/* Story, values, trust section cards */
+.story-card, .values-card, .trust-card { color: var(--ink-900); }
+
+.story-card h2, .values-card h2, .trust-card h2 {
+  margin: 0 0 12px;
+  font-size: clamp(1.15rem, 1vw + 1rem, 1.5rem);
+  font-weight: 900;
+}
+
+.story-card p { margin: 0 0 12px; line-height: 1.6; }
+.story-card p:last-child { margin-bottom: 0; }
+.trust-card > p { margin: 0 0 10px; line-height: 1.55; color: var(--text-muted); }
+
+.values-card ul, .trust-card .trust-points {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.values-card li, .trust-card .trust-points li {
+  padding: 12px 16px;
+  background: rgba(255,255,255,0.5);
+  border: 1px solid rgba(15,44,42,0.08);
+  border-radius: 10px;
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+/* Feature icon grid */
+.feature-card-group { color: var(--ink-900); }
+
+.feature-card-group > h2 {
+  margin: 0 0 6px;
+  font-size: clamp(1.15rem, 1vw + 1rem, 1.5rem);
+  font-weight: 900;
+}
+
+.feature-intro {
+  margin: 0 0 20px;
+  color: var(--text-muted);
+  font-size: 0.93rem;
+  line-height: 1.5;
+}
+
+.feature-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: clamp(10px, 2vw, 16px);
+}
+
+@media (min-width: 600px) { .feature-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 880px) { .feature-grid { grid-template-columns: repeat(4, 1fr); } }
+
+.feature-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: clamp(14px, 2vw, 18px) clamp(10px, 1.5vw, 14px);
+  background: rgba(255,255,255,0.65);
+  border: 1px solid rgba(15,44,42,0.08);
+  border-radius: 14px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.feature-item:hover { transform: translateY(-2px); box-shadow: 0 6px 18px rgba(15,44,42,0.1); }
+
+.feature-item img {
+  width: 44px;
+  height: 44px;
+  object-fit: contain;
+  display: block;
+}
+
+.feature-item span {
+  font-size: 0.8rem;
+  line-height: 1.45;
+  font-weight: 600;
+  color: var(--ink-900);
+}
+
+/* Impact / donate link card */
+.impact-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  color: var(--ink-900);
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.impact-card:hover { transform: translateY(-2px); box-shadow: 0 12px 30px rgba(15,44,42,0.15); }
+.impact-card img { height: 60px; width: auto; flex-shrink: 0; }
+.impact-card h2 { margin: 0 0 6px; font-size: 1.2rem; font-weight: 900; }
+.impact-card p { margin: 0; font-size: 0.9rem; line-height: 1.5; color: var(--text-muted); }
+
+@media (max-width: 480px) { .impact-card { flex-direction: column; text-align: center; } }

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -9,19 +8,21 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="stylesheet" href="global.css" />
-
   <title>CloseDose – Medication Guides</title>
 </head>
 <body>
   <div class="wrap">
-    
+
     <header>
-      <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      <a href="index.html" class="header-link">
+        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
       </button>
     </header>
+
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
       <img src="cappy/assets/Cappy circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
@@ -29,707 +30,422 @@
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
       </div>
     </button>
+
     <main>
       <div class="layout layout--inline">
-        <section class="card hero">
-          <div class="tab-stack" aria-hidden="true"><span></span><span></span><span></span></div>
+
+        <!-- Hero -->
+        <section class="card guide-hero">
           <h1>Fever &amp; Pain Medication Guides</h1>
-          <p>Use these quick references to view common acetaminophen and ibuprofen products for infants and children. Double-check concentrations and dosing with your pediatrician or pharmacist.</p>
+          <p>Quick-reference product galleries for acetaminophen and ibuprofen, organized by concentration so you always grab the right bottle.</p>
         </section>
 
-        <section class="card guide-section" id="guides">
-          <div class="guide-intro">
-            <h2>Product comparisons</h2>
-            <p>Swipe through brand-name and generic options, then review dosing reminders tailored to your patient.</p>
+        <!-- ══════════════════════════════════════
+             ACETAMINOPHEN GUIDE
+        ══════════════════════════════════════ -->
+        <article class="card med-guide" id="acetaminophen">
+          <div class="med-guide__header">
+            <div class="med-guide__header-text">
+              <h2>Acetaminophen</h2>
+              <p>Safe for all ages, including infants under 6 months. All liquid suspensions listed below share the same concentration.</p>
+            </div>
+            <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
           </div>
 
-          <div class="card guide-grid">
-            <article class="guide-card guide-card--acetaminophen" id="acetaminophen" data-carousel>
-              <h2>Acetaminophen <span class="medication-concentration">[160 mg / 5 mL]</span></h2>
-              <div class="carousel-track">
-                <figure class="carousel-slide">
-                  <img src="images/Acetaminophen/Tylenol acetaminophen iso.png" alt="Tylenol children's acetaminophen suspension 160 mg per 5 mL">
-                  <figcaption>Tylenol® Children's Oral Suspension</figcaption>
-                </figure>
-                <figure class="carousel-slide">
-                  <img src="images/Acetaminophen/amazon acetaminophen iso.png" alt="Amazon Basics children's acetaminophen 160 mg per 5 mL">
-                  <figcaption>Amazon Basics® Children's Acetaminophen</figcaption>
-                </figure>
-                <figure class="carousel-slide">
-                  <img src="images/Acetaminophen/Target acetaminophen iso.png" alt="Target up & up children's acetaminophen 160mg per 5 mL">
-                  <figcaption>up &amp; up® Children's Acetaminophen</figcaption>
-                </figure>
-                <figure class="carousel-slide">
-                  <img src="images/Acetaminophen/Equate acetaminophen iso.png" alt="Walmart Equate children's acetaminophen 160mg per 5 mL">
-                  <figcaption>Equate® Children's Acetaminophen</figcaption>
-                </figure>
+          <!-- Featured Brands -->
+          <div class="product-section">
+            <p class="product-section__label">Featured brands</p>
+            <div class="product-strip" id="ace-strip-brands" role="list" aria-label="Acetaminophen featured brands">
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Acetaminophen/Tylenol acetaminophen iso.png" alt="Tylenol Children's Oral Suspension 160 mg per 5 mL" loading="eager" />
+                </div>
+                <p class="product-card__name">Tylenol® Children's</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
               </div>
-              <div class="carousel-controls">
-                <button type="button" data-carousel-prev aria-label="Show previous acetaminophen product">←</button>
-                <div class="carousel-dots"></div>
-                <button type="button" data-carousel-next aria-label="Show next acetaminophen product">→</button>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Acetaminophen/amazon acetaminophen iso.png" alt="Amazon Basics Children's Acetaminophen 160 mg per 5 mL" loading="lazy" />
+                </div>
+                <p class="product-card__name">Amazon Basics® Children's</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
               </div>
-              <div class="mini-carousel-stack">
-                <section
-                  class="mini-carousel"
-                  data-carousel
-                  aria-label="Acetaminophen liquids gallery"
-                >
-                  <h3 class="mini-carousel__heading">160 mg / 5 mL liquids</h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k1.png"
-                          alt="Children's acetaminophen product photo (variant 1)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k2.png"
-                          alt="Children's acetaminophen product photo (variant 2)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k3.png"
-                          alt="Children's acetaminophen product photo (variant 3)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k4.png"
-                          alt="Children's acetaminophen product photo (variant 4)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k5.png"
-                          alt="Children's acetaminophen product photo (variant 5)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k6.png"
-                          alt="Children's acetaminophen product photo (variant 6)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k7.png"
-                          alt="Children's acetaminophen product photo (variant 7)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k8.png"
-                          alt="Children's acetaminophen product photo (variant 8)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ace/k/k9.png"
-                          alt="Children's acetaminophen product photo (variant 9)"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children's Acetaminophen Suspension</span>
-                        <span class="mini-carousel__meta">160 mg / 5 mL</span>
-                      </figcaption>
-                    </figure>
-                  </div>
-                  <div class="mini-carousel__controls">
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-prev
-                      aria-label="Show previous acetaminophen product"
-                    >
-                      ←
-                    </button>
-                    <div class="mini-carousel__dots carousel-dots"></div>
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-next
-                      aria-label="Show next acetaminophen product"
-                    >
-                      →
-                    </button>
-                  </div>
-                </section>
-                <section
-                  class="mini-carousel"
-                  data-carousel
-                  aria-label="Alternate acetaminophen products"
-                >
-                  <h3 class="mini-carousel__heading">Chewables, meltaways &amp; more</h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23fde68a%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23fde68a%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%F0%9F%8D%93%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3EMeltaways%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E160%20mg%20each%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing Tylenol Children's Meltaways acetaminophen tablets 160 mg each"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Tylenol® Children's Meltaways</span>
-                        <span class="mini-carousel__meta">160 mg orally disintegrating tablet</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23fbcfe8%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23fbcfe8%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%F0%9F%A7%A1%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3EChewables%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E160%20mg%20each%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing children's chewable acetaminophen tablets 160 mg each"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Generic Children's Chewables</span>
-                        <span class="mini-carousel__meta">160 mg chewable tablet</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23bfdbfe%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23bfdbfe%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%F0%9F%8C%99%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3ESuppository%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E80-160%20mg%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing acetaminophen suppositories in the 80-160 mg range"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Rectal Suppositories</span>
-                        <span class="mini-carousel__meta">80-160 mg per dose (check label)</span>
-                      </figcaption>
-                    </figure>
-                  </div>
-                  <div class="mini-carousel__controls">
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-prev
-                      aria-label="Show previous alternate acetaminophen product"
-                    >
-                      ←
-                    </button>
-                    <div class="mini-carousel__dots carousel-dots"></div>
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-next
-                      aria-label="Show next alternate acetaminophen product"
-                    >
-                      →
-                    </button>
-                  </div>
-                </section>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Acetaminophen/Target acetaminophen iso.png" alt="Target up &amp; up Children's Acetaminophen 160 mg per 5 mL" loading="lazy" />
+                </div>
+                <p class="product-card__name">up &amp; up® Children's</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
               </div>
-              <div class="acetaminophen-safety">
-                <h3>Safety Tips</h3>
-                <ul>
-                  <li>Do not exceed 6 doses in 24 hours.</li>
-                  <li>&lt;6 months: dose every 4 hours as needed.</li>
-                  <li>&gt;6 months: dose every 6 hours as needed.</li>
-                  <li>Alternate acetaminophen and ibuprofen (every 6 hours) to allow dosing every 3 hours.</li>
-                  <li>Seek care for infants under 2 months with fever or fever lasting longer than 3 days.</li>
-                  <li>Keep a log of medication, time, and dose to avoid repeat dosing.</li>
-                </ul>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Acetaminophen/Equate acetaminophen iso.png" alt="Equate Children's Acetaminophen 160 mg per 5 mL" loading="lazy" />
+                </div>
+                <p class="product-card__name">Equate® Children's</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
               </div>
-            </article>
-
-            <article class="guide-card guide-card--ibuprofen" id="ibuprofen">
-              <h2>Ibuprofen Comparisons</h2>
-              <p class="ibuprofen-lede">Review children's and infant ibuprofen suspensions side-by-side to ensure the correct strength for your patient.</p>
-              <div class="ibuprofen-comparison">
-                <section class="ibuprofen-panel" id="ibuprofen-children" data-carousel>
-                  <h3>Children's Ibuprofen <span class="medication-concentration">[100 mg / 5 mL]</span></h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin Children's ibuprofen 100 mg per 5 mL">
-                      <figcaption>Motrin® Children's Suspension</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil Children's ibuprofen 100 mg per 5 mL">
-                      <figcaption>Advil® Children's Suspension</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon Basics Children's ibuprofen 100 mg per 5 mL">
-                      <figcaption>Amazon Basics® Children's Ibuprofen</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target up &amp; up Children's ibuprofen 100 mg per 5 mL">
-                      <figcaption>up &amp; up® Children's Ibuprofen</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate Children's ibuprofen 100 mg per 5 mL">
-                      <figcaption>Equate® Children's Ibuprofen</figcaption>
-                    </figure>
-                  </div>
-                  <div class="carousel-controls">
-                    <button type="button" data-carousel-prev aria-label="Show previous children's ibuprofen product">←</button>
-                    <div class="carousel-dots"></div>
-                    <button type="button" data-carousel-next aria-label="Show next children's ibuprofen product">→</button>
-                  </div>
-                </section>
-
-                <section class="ibuprofen-panel" id="ibuprofen-infant" data-carousel>
-                  <h3>Infant Ibuprofen <span class="medication-concentration">[50 mg / 1.25 mL]</span></h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Infant's Motrin concentrated ibuprofen 50 mg per 1.25 mL">
-                      <figcaption>Infant's Motrin® Concentrated Drops</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png" alt="Infants' Advil concentrated ibuprofen 50 mg per 1.25 mL">
-                      <figcaption>Infants' Advil® Concentrated Drops</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon Basics infant ibuprofen 50 mg per 1.25 mL">
-                      <figcaption>Amazon Basics® Infant Ibuprofen</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Infants/Target Infant ibuprofen iso.png" alt="Target up &amp; up infant ibuprofen 50 mg per 1.25 mL">
-                      <figcaption>up &amp; up® Infant Ibuprofen</figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <img src="images/Ibuprofen/Infants/Equate Infant ibuprofen iso.png" alt="Equate infant ibuprofen 50 mg per 1.25 mL">
-                      <figcaption>Equate® Infant Ibuprofen</figcaption>
-                    </figure>
-                  </div>
-                  <div class="carousel-controls">
-                    <button type="button" data-carousel-prev aria-label="Show previous infant ibuprofen product">←</button>
-                    <div class="carousel-dots"></div>
-                    <button type="button" data-carousel-next aria-label="Show next infant ibuprofen product">→</button>
-                  </div>
-                </section>
-              </div>
-              <div class="mini-carousel-stack">
-                <section
-                  class="mini-carousel"
-                  data-carousel
-                  aria-label="Children's ibuprofen liquids"
-                >
-                  <h3 class="mini-carousel__heading">Children's 100 mg / 5 mL</h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k1.png"
-                          alt="Quality Choice children's ibuprofen oral suspension box showing 100 mg per 5 mL dosing information."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Quality Choice® Children’s Ibuprofen</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k2.png"
-                          alt="Quality Choice children's ibuprofen packaging highlighting an alcohol-free, non-staining suspension."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Quality Choice® Dye-Free Suspension</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k3.png"
-                          alt="Dye-free children’s ibuprofen 100 mg per 5 mL box for ages 2 to 11 years."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Dye-Free Children’s Ibuprofen</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k4.png"
-                          alt="Equate children's ibuprofen oral suspension 100 mg per 5 mL packaging."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Equate® Children’s Ibuprofen</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k5.png"
-                          alt="Children's Advil oral suspension 100 mg per 5 mL bottle and box."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children’s Advil® Suspension</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k6.png"
-                          alt="Generic children's ibuprofen packaging comparing to Children's Motrin for ages 2 to 11 years."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Compare to Children’s Motrin®</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k7.png"
-                          alt="Children's ibuprofen dosing directions panel noting 100 mg per 5 mL oral suspension."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children’s Ibuprofen Directions</span>
-                        <span class="mini-carousel__meta">Dosing guidance (100 mg / 5 mL)</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k8.png"
-                          alt="Store-brand children's ibuprofen bubble gum flavor package comparing to Children's Motrin."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Store-Brand Bubble Gum Ibuprofen</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Carousel/ibu/k9.png"
-                          alt="Children's ibuprofen oral suspension bottle with a lasts up to 8 hours callout."
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Children’s Ibuprofen (8 Hour Relief)</span>
-                        <span class="mini-carousel__meta">100 mg / 5 mL oral suspension</span>
-                      </figcaption>
-                    </figure>
-                  </div>
-                  <div class="mini-carousel__controls">
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-prev
-                      aria-label="Show previous children's ibuprofen product"
-                    >
-                      ←
-                    </button>
-                    <div class="mini-carousel__dots carousel-dots"></div>
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-next
-                      aria-label="Show next children's ibuprofen product"
-                    >
-                      →
-                    </button>
-                  </div>
-                </section>
-                <section
-                  class="mini-carousel"
-                  data-carousel
-                  aria-label="Infant ibuprofen liquids"
-                >
-                  <h3 class="mini-carousel__heading">Infant 50 mg / 1.25 mL</h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png"
-                          alt="Infant's Motrin concentrated ibuprofen 50 mg per 1.25 mL"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Infant's Motrin® Concentrated Drops</span>
-                        <span class="mini-carousel__meta">50 mg / 1.25 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png"
-                          alt="Infants' Advil concentrated ibuprofen 50 mg per 1.25 mL"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Infants' Advil® Concentrated Drops</span>
-                        <span class="mini-carousel__meta">50 mg / 1.25 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png"
-                          alt="Amazon Basics infant ibuprofen 50 mg per 1.25 mL"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Amazon Basics® Infant Ibuprofen</span>
-                        <span class="mini-carousel__meta">50 mg / 1.25 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Ibuprofen/Infants/Target Infant ibuprofen iso.png"
-                          alt="Target up &amp; up infant ibuprofen 50 mg per 1.25 mL"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">up &amp; up® Infant Ibuprofen</span>
-                        <span class="mini-carousel__meta">50 mg / 1.25 mL</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="images/Ibuprofen/Infants/Equate Infant ibuprofen iso.png"
-                          alt="Equate infant ibuprofen 50 mg per 1.25 mL"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Equate® Infant Ibuprofen</span>
-                        <span class="mini-carousel__meta">50 mg / 1.25 mL</span>
-                      </figcaption>
-                    </figure>
-                  </div>
-                  <div class="mini-carousel__controls">
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-prev
-                      aria-label="Show previous infant ibuprofen product"
-                    >
-                      ←
-                    </button>
-                    <div class="mini-carousel__dots carousel-dots"></div>
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-next
-                      aria-label="Show next infant ibuprofen product"
-                    >
-                      →
-                    </button>
-                  </div>
-                </section>
-                <section
-                  class="mini-carousel"
-                  data-carousel
-                  aria-label="Other ibuprofen formulations"
-                >
-                  <h3 class="mini-carousel__heading">Tablets, capsules &amp; chewables</h3>
-                  <div class="carousel-track">
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23fecdd3%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23fecdd3%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%F0%9F%8D%8A%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3EChewables%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E100%20mg%20each%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing Motrin children's chewable ibuprofen tablets 100 mg each"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Motrin® Children's Chewables</span>
-                        <span class="mini-carousel__meta">100 mg chewable tablet</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23d8b4fe%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23d8b4fe%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%E2%AD%90%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3EJunior%20Tabs%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E100%20mg%20each%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing Advil Junior Strength ibuprofen tablets 100 mg each"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Advil® Junior Strength Tablets</span>
-                        <span class="mini-carousel__meta">100 mg coated tablet</span>
-                      </figcaption>
-                    </figure>
-                    <figure class="carousel-slide">
-                      <div class="mini-carousel__image">
-                        <img
-                          src="data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22320%22%20height%3D%22320%22%20viewBox%3D%220%200%20320%20320%22%3E%0A%20%20%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%20%20%3ClinearGradient%20id%3D%22miniBadgeGradient%22%20x1%3D%2250%25%22%20x2%3D%2250%25%22%20y1%3D%220%25%22%20y2%3D%22100%25%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23bbf7d0%22%20stop-opacity%3D%220.92%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23bbf7d0%22%20stop-opacity%3D%221%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22320%22%20height%3D%22320%22%20rx%3D%2248%22%20fill%3D%22url(%23miniBadgeGradient)%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22120%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2276%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E%F0%9F%92%8A%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22188%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2234%22%20font-weight%3D%22700%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3ECaplets%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3Ctext%20x%3D%2250%25%22%20y%3D%22232%22%20font-family%3D%22Nunito%2C%20Arial%2C%20sans-serif%22%20font-size%3D%2226%22%20text-anchor%3D%22middle%22%20fill%3D%22%230f2c2a%22%3E200%20mg%20each%3C%2Ftext%3E%0A%20%20%20%20%20%20%3C%2Fsvg%3E"
-                          alt="Illustration representing generic ibuprofen caplets 200 mg each"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </div>
-                      <figcaption>
-                        <span class="mini-carousel__caption">Ibuprofen Caplets</span>
-                        <span class="mini-carousel__meta">200 mg tablet/capsule (adolescents+)</span>
-                      </figcaption>
-                    </figure>
-                  </div>
-                  <div class="mini-carousel__controls">
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-prev
-                      aria-label="Show previous ibuprofen formulation"
-                    >
-                      ←
-                    </button>
-                    <div class="mini-carousel__dots carousel-dots"></div>
-                    <button
-                      type="button"
-                      class="mini-carousel__control"
-                      data-carousel-next
-                      aria-label="Show next ibuprofen formulation"
-                    >
-                      →
-                    </button>
-                  </div>
-                </section>
-              </div>
-              <div class="ibuprofen-safety">
-                <h3>Safety Tips</h3>
-                <ul>
-                  <li>Do not give to infants &lt;6 months unless directed by a doctor.</li>
-                  <li>Allow at least 6 hours between doses.</li>
-                  <li>Do not exceed 4 doses in 24 hours.</li>
-                  <li>Give with food or milk to lessen stomach upset.</li>
-                </ul>
-              </div>
-            </article>
+            </div>
           </div>
-        </section>
-<section class="card card--disclaimer" role="button" tabindex="0" aria-expanded="false">
+
+          <!-- More Market Products -->
+          <div class="product-section">
+            <p class="product-section__label">More products at your pharmacy</p>
+            <div class="product-strip" id="ace-strip-more" role="list" aria-label="More acetaminophen suspension products">
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k1.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 1" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k2.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 2" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k3.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 3" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k4.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 4" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k5.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 5" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k6.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 6" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k7.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 7" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k8.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 8" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+              <div class="product-card" role="listitem">
+                <div class="product-card__img-wrap">
+                  <img class="product-card__img" src="images/Carousel/ace/k/k9.png" alt="Generic children's acetaminophen suspension 160 mg per 5 mL, variant 9" loading="lazy" decoding="async" />
+                </div>
+                <p class="product-card__name">Children's Acetaminophen Suspension</p>
+                <span class="conc-badge conc-badge--ace">160 mg / 5 mL</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Other Acetaminophen Formulations -->
+          <div class="product-section">
+            <p class="product-section__label">Other formulations</p>
+            <div class="formulation-grid">
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">🍓</div>
+                <p class="formulation-card__name">Meltaways</p>
+                <p class="formulation-card__dose">160 mg each · orally disintegrating</p>
+              </div>
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">🍬</div>
+                <p class="formulation-card__name">Chewable Tablets</p>
+                <p class="formulation-card__dose">160 mg each</p>
+              </div>
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">🌙</div>
+                <p class="formulation-card__name">Suppositories</p>
+                <p class="formulation-card__dose">80–160 mg · check label carefully</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Acetaminophen Safety Tips -->
+          <div class="safety-card" aria-label="Acetaminophen safety tips">
+            <p class="safety-card__title">Safety tips</p>
+            <ul>
+              <li>Do not exceed 5 doses in 24 hours.</li>
+              <li>Under 6 months: may dose every 4–6 hours as needed.</li>
+              <li>Over 6 months: dose every 6 hours as needed.</li>
+              <li>Alternating acetaminophen and ibuprofen every 3 hours (offset by 3 h) can improve fever and pain control — ask your pediatrician.</li>
+              <li>All liquids on this page share the same 160 mg / 5 mL concentration — they are interchangeable.</li>
+              <li>Keep a log of medication, time, and dose to prevent accidental repeat dosing.</li>
+              <li>Seek care for any infant under 2 months with fever, or for fever lasting more than 3 days in older children.</li>
+            </ul>
+          </div>
+        </article>
+
+        <!-- ══════════════════════════════════════
+             IBUPROFEN GUIDE
+        ══════════════════════════════════════ -->
+        <article class="card med-guide" id="ibuprofen">
+          <div class="med-guide__header">
+            <div class="med-guide__header-text">
+              <h2>Ibuprofen</h2>
+              <p>Available in two concentrations. The infant drops are more concentrated — always confirm which bottle you have before measuring a dose.</p>
+            </div>
+          </div>
+
+          <!-- Age restriction notice -->
+          <div class="med-warning">
+            Not recommended for infants under 6 months of age unless directed by a physician. Always give with food or milk to reduce stomach upset.
+          </div>
+
+          <!-- Concentration tab switcher -->
+          <div class="conc-switcher" role="tablist" aria-label="Select ibuprofen concentration">
+            <button
+              class="conc-tab is-active"
+              role="tab"
+              aria-selected="true"
+              aria-controls="ibu-children"
+              data-conc-target="ibu-children"
+              type="button"
+            >
+              Children's
+              <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+            </button>
+            <button
+              class="conc-tab"
+              role="tab"
+              aria-selected="false"
+              aria-controls="ibu-infant"
+              data-conc-target="ibu-infant"
+              type="button"
+            >
+              Infant Drops
+              <span class="conc-badge conc-badge--infant">50 mg / 1.25 mL</span>
+            </button>
+          </div>
+
+          <!-- ── Children's Panel ── -->
+          <div class="conc-panel is-active" id="ibu-children" role="tabpanel" aria-label="Children's ibuprofen 100 mg per 5 mL">
+
+            <div class="product-section">
+              <p class="product-section__label">Featured brands · 100 mg / 5 mL</p>
+              <div class="product-strip" role="list" aria-label="Children's ibuprofen featured brands">
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin Children's Ibuprofen Suspension 100 mg per 5 mL" loading="eager" />
+                  </div>
+                  <p class="product-card__name">Motrin® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil Children's Ibuprofen Suspension 100 mg per 5 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">Advil® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon Basics Children's Ibuprofen Suspension 100 mg per 5 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">Amazon Basics® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target up &amp; up Children's Ibuprofen Suspension 100 mg per 5 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">up &amp; up® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate Children's Ibuprofen Suspension 100 mg per 5 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">Equate® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="product-section">
+              <p class="product-section__label">More children's products · 100 mg / 5 mL</p>
+              <div class="product-strip" role="list" aria-label="More children's ibuprofen products">
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k1.png" alt="Quality Choice Children's Ibuprofen Suspension 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Quality Choice® Children's</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k2.png" alt="Quality Choice Dye-Free Children's Ibuprofen 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Quality Choice® Dye-Free</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k3.png" alt="Dye-free Children's Ibuprofen 100 mg per 5 mL for ages 2 to 11" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Dye-Free Children's Ibuprofen</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k4.png" alt="Equate Children's Ibuprofen Oral Suspension 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Equate® Children's Suspension</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k5.png" alt="Children's Advil Oral Suspension 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Advil® Children's Suspension</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k6.png" alt="Store-brand ibuprofen compare to Children's Motrin 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Store Brand (compare to Motrin®)</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k7.png" alt="Children's Ibuprofen dosing directions panel 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Children's Ibuprofen (Dosing Panel)</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k8.png" alt="Bubble gum flavored store-brand ibuprofen suspension 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Bubble Gum Flavor Suspension</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Carousel/ibu/k9.png" alt="Children's Ibuprofen 8-hour relief suspension 100 mg per 5 mL" loading="lazy" decoding="async" />
+                  </div>
+                  <p class="product-card__name">Children's Ibuprofen (8-hr relief)</p>
+                  <span class="conc-badge conc-badge--child">100 mg / 5 mL</span>
+                </div>
+              </div>
+            </div>
+
+          </div><!-- /ibu-children -->
+
+          <!-- ── Infant Panel ── -->
+          <div class="conc-panel" id="ibu-infant" role="tabpanel" aria-label="Infant ibuprofen drops 50 mg per 1.25 mL">
+
+            <div class="med-warning">
+              <strong>Infant drops are more concentrated.</strong> The 50 mg / 1.25 mL formula delivers the same mg of ibuprofen in a smaller volume — do not use the children's dosing chart with this product, and vice versa. Double-check the label before every dose.
+            </div>
+
+            <div class="product-section">
+              <p class="product-section__label">Infant concentrated drops · 50 mg / 1.25 mL</p>
+              <div class="product-strip" role="list" aria-label="Infant ibuprofen drop products">
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Infant's Motrin Concentrated Ibuprofen Drops 50 mg per 1.25 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">Infant's Motrin® Concentrated Drops</p>
+                  <span class="conc-badge conc-badge--infant">50 mg / 1.25 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon Basics Infant Ibuprofen Drops 50 mg per 1.25 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">Amazon Basics® Infant Drops</p>
+                  <span class="conc-badge conc-badge--infant">50 mg / 1.25 mL</span>
+                </div>
+                <div class="product-card" role="listitem">
+                  <div class="product-card__img-wrap">
+                    <img class="product-card__img" src="images/Ibuprofen/Infants/Target Infant ibuprofen iso.png" alt="Target up &amp; up Infant Ibuprofen Drops 50 mg per 1.25 mL" loading="lazy" />
+                  </div>
+                  <p class="product-card__name">up &amp; up® Infant Drops</p>
+                  <span class="conc-badge conc-badge--infant">50 mg / 1.25 mL</span>
+                </div>
+              </div>
+            </div>
+
+          </div><!-- /ibu-infant -->
+
+          <!-- Other Ibuprofen Formulations (shown regardless of tab) -->
+          <div class="product-section">
+            <p class="product-section__label">Other formulations · older children &amp; adolescents</p>
+            <div class="formulation-grid">
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">🍊</div>
+                <p class="formulation-card__name">Children's Chewables</p>
+                <p class="formulation-card__dose">100 mg each · ages 2–11</p>
+              </div>
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">⭐</div>
+                <p class="formulation-card__name">Junior Strength Tablets</p>
+                <p class="formulation-card__dose">100 mg each · ages 6–11</p>
+              </div>
+              <div class="formulation-card">
+                <div class="formulation-card__emoji">💊</div>
+                <p class="formulation-card__name">Adult Tablets / Caplets</p>
+                <p class="formulation-card__dose">200 mg each · adolescents only</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Ibuprofen Safety Tips -->
+          <div class="safety-card" aria-label="Ibuprofen safety tips">
+            <p class="safety-card__title">Safety tips</p>
+            <ul>
+              <li>Do not give to infants under 6 months unless directed by a physician.</li>
+              <li>Allow at least 6 hours between doses. Do not exceed 4 doses in 24 hours.</li>
+              <li>Give with food or milk to reduce stomach upset.</li>
+              <li><strong>Infant drops (50 mg / 1.25 mL) and Children's suspension (100 mg / 5 mL) require different dosing charts</strong> — never use one chart for the other product.</li>
+              <li>Avoid in children with kidney disease, dehydration, or known NSAIDs allergy.</li>
+              <li>Alternating with acetaminophen every 3 hours can improve pain and fever control — confirm the schedule with your pediatrician first.</li>
+            </ul>
+          </div>
+        </article>
+
+        <!-- Disclaimer -->
+        <section class="card card--disclaimer" role="button" tabindex="0" aria-expanded="false">
           <div class="disclaimer-header">
             <span class="eyebrow">Disclaimer</span>
-            <h2>Medication Safety & Usage</h2>
+            <h2>Medication Safety &amp; Usage</h2>
             <p>Tap to read important safety information</p>
           </div>
           <div class="disclaimer-content" hidden>
             <button class="disclaimer-close" aria-label="Close disclaimer">&times;</button>
-            <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes and should be verified with a healthcare provider.</p>
+            <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider or pharmacist before use.</p>
             <ul>
-              <li>Always use the dosing device (syringe or cup) that came with the medication.</li>
-              <li>Confirm your child's weight if it has been more than 3 months.</li>
-              <li>Contact Poison Control (1-800-222-1222) if an overdose is suspected.</li>
+              <li>Always use the measuring device (oral syringe or dosing cup) that came with the medication — household spoons are not accurate.</li>
+              <li>Confirm your child's current weight if it has been more than 3 months since the last measurement.</li>
+              <li>Contact Poison Control (1-800-222-1222) immediately if an overdose is suspected.</li>
+              <li>All product photos are for identification purposes only; availability may vary by region.</li>
             </ul>
           </div>
         </section>
+
       </div>
     </main>
   </div>
-  
+
   <footer class="cd-footer">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
     <nav class="cd-legal cd-legal--full">
@@ -763,7 +479,55 @@
       </form>
     </div>
   </div>
+
   <script src="global.js" defer></script>
-  <script src="script.js"></script>
+  <script>
+    // Ibuprofen concentration tab switcher
+    (function () {
+      const switcher = document.querySelector('.conc-switcher');
+      if (!switcher) return;
+      const tabs = switcher.querySelectorAll('.conc-tab');
+      tabs.forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          tabs.forEach(function (t) {
+            t.classList.remove('is-active');
+            t.setAttribute('aria-selected', 'false');
+          });
+          tab.classList.add('is-active');
+          tab.setAttribute('aria-selected', 'true');
+          const targetId = tab.getAttribute('data-conc-target');
+          document.querySelectorAll('.conc-panel').forEach(function (panel) {
+            panel.classList.remove('is-active');
+          });
+          var target = document.getElementById(targetId);
+          if (target) target.classList.add('is-active');
+        });
+      });
+    })();
+
+    // Mouse-drag scroll for product strips on desktop
+    (function () {
+      document.querySelectorAll('.product-strip').forEach(function (strip) {
+        var isDown = false;
+        var startX;
+        var scrollLeft;
+        strip.addEventListener('mousedown', function (e) {
+          isDown = true;
+          strip.classList.add('is-dragging');
+          startX = e.pageX - strip.offsetLeft;
+          scrollLeft = strip.scrollLeft;
+        });
+        strip.addEventListener('mouseleave', function () { isDown = false; strip.classList.remove('is-dragging'); });
+        strip.addEventListener('mouseup', function () { isDown = false; strip.classList.remove('is-dragging'); });
+        strip.addEventListener('mousemove', function (e) {
+          if (!isDown) return;
+          e.preventDefault();
+          var x = e.pageX - strip.offsetLeft;
+          var walk = (x - startX) * 1.5;
+          strip.scrollLeft = scrollLeft - walk;
+        });
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Medication Guides**: Replaced the broken JS carousels (which had zero CSS and rendered all slides stacked) with CSS scroll-snap horizontal product strips — works natively on touch devices and supports mouse-drag on desktop
- **Ibuprofen concentration switcher**: Added a polished pill-style tab toggle between Children's (100 mg/5 mL) and Infant Drops (50 mg/1.25 mL), each with its own product gallery and prominent concentration warnings
- **About page**: Fixed the feature icon grid (2→3→4 column responsive layout), rescaled icons to a consistent 44px, removed two duplicate feature items, and corrected a broken `donation.html` → `donations.html` link

## Key design changes

### Medication Guides (`medication-guides.html`)
- Products displayed as scrollable card galleries segregated by concentration, with a colored concentration badge on **every card** (amber for acetaminophen, blue for children's ibuprofen, purple for infant drops)
- Clear `⚠` warning callout explaining that infant drops and children's suspension require **different dosing charts** and must never be interchanged
- Formulation cards (chewables, meltaways, suppositories, junior tabs) displayed in a 3-column auto-fit grid with emoji identifiers for fast visual scanning
- Safety quick-reference checklist rendered as a teal-tinted callout card at the bottom of each section
- Guide hero uses a transparent card so white text reads on the dark background

### About page (`about.html`)
- Feature grid: `repeat(2,1fr)` on mobile → `repeat(3,1fr)` on tablet → `repeat(4,1fr)` on desktop
- Each feature item is a rounded card with hover lift effect
- All SVG icons are capped at 44×44 px via CSS (`object-fit: contain`) — previously unstyled so they rendered at native size
- CTA buttons use the site's teal primary colour and a subtle secondary style

### CSS (`global.css` +481 lines)
- `.guide-hero`, `.med-guide`, `.med-guide__header` — guide layout
- `.conc-badge` with three colour variants (`--ace`, `--child`, `--infant`)
- `.conc-switcher` / `.conc-tab` / `.conc-panel` — tab switcher system
- `.product-strip` (CSS `scroll-snap-type: x mandatory`) + `.product-card`
- `.formulation-grid` / `.formulation-card`
- `.safety-card` with checkmark list
- `.med-warning` inline alert
- `.hero-about`, `.feature-grid`, `.feature-item`, `.about-cta`, `.story-card`, `.values-card`, `.trust-card`, `.impact-card`

## Test plan
- [ ] Open `medication-guides.html` on mobile — verify both product strips scroll horizontally with snap
- [ ] Tap "Infant Drops" tab — confirm concentration panel switches and warning displays
- [ ] Tap "Children's" tab — confirm panel switches back correctly
- [ ] Open `about.html` — verify icon grid renders 2 cols mobile / 3 cols tablet / 4 cols desktop
- [ ] Confirm all icon images load (44px, correct SVG paths)
- [ ] Verify disclaimer card expands on scroll to page bottom on both pages
- [ ] Check keyboard navigation: tab switcher is navigable with arrow keys via `role="tab"`

https://claude.ai/code/session_01HAnEUqSvnvxkfxo1U3aYc3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnEUqSvnvxkfxo1U3aYc3)_