### PR TITLE
Fix website styling: single-column scrolling and clean interface

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -169,15 +169,15 @@ main {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(24px, 4vw, 40px);
-  padding: clamp(8px, 2vw, 24px) clamp(18px, 5vw, 52px) clamp(64px, 8vw, 80px);
+  gap: clamp(16px, 3vw, 28px);
+  padding: clamp(8px, 2vw, 20px) clamp(16px, 4vw, 32px) clamp(48px, 6vw, 64px);
   box-sizing: border-box;
   overflow-x: hidden;
 }
 
 /* --- Hero --- */
 .hero {
-  width: min(1200px, 100%);
+  width: min(720px, 100%);
   text-align: center;
   color: var(--white);
   padding: clamp(8px, 2vw, 16px) 0 clamp(8px, 2vw, 12px);
@@ -212,65 +212,33 @@ main {
   color: rgba(255, 255, 255, 0.86);
 }
 
-/* --- Layout: grid (calculator + info column) --- */
+/* --- Layout: single-column scrolling --- */
 .layout {
-  width: min(1200px, 100%);
+  width: min(720px, 100%);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: clamp(20px, 3vw, 32px);
+  gap: clamp(16px, 2.5vw, 24px);
 }
 
 .layout--grid,
 .layout--secondary {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: clamp(20px, 3vw, 32px);
-}
-
-@media (min-width: 961px) {
-  .layout--grid {
-    grid-template-columns: minmax(280px, 1fr) minmax(0, 1.4fr);
-    align-items: start;
-  }
-
-  .layout--secondary {
-    grid-template-columns: 1.15fr 1fr;
-    align-items: start;
-  }
-
-  .calculator-column {
-    position: sticky;
-    top: 24px;
-  }
-}
-
-@media (min-width: 1280px) {
-  .layout--grid {
-    grid-template-columns: minmax(320px, 1fr) minmax(0, 1.5fr);
-  }
-}
-
-/* On mobile/tablet show calculator first, then the info column */
-@media (max-width: 960px) {
-  .layout--grid {
-    display: flex;
-    flex-direction: column;
-  }
-  .layout--grid .calculator-column { order: 1; }
-  .layout--grid .info-column { order: 2; }
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2.5vw, 24px);
 }
 
 .info-column {
-  display: grid;
-  gap: clamp(14px, 2vw, 20px);
-  align-content: start;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2vw, 16px);
 }
 
 .calculator-column {
-  display: grid;
-  gap: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .calculator-trust {
@@ -306,7 +274,7 @@ main {
   animation: slam-in 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
 }
 
-.layout > .card { max-width: min(720px, 100%); margin-inline: auto; }
+.layout > .card { width: 100%; }
 
 .card:nth-child(2) { animation-delay: 0.08s; }
 .card:nth-child(3) { animation-delay: 0.16s; }

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,15 @@
       </section>
 
       <div class="layout layout--grid">
+        <div class="calculator-column">
+          <div class="calculator-widget-host" id="calculator-card" data-calculator-root></div>
+
+          <p class="calculator-trust">
+            CloseDose is free, ad-free, and reviewed by an actively practicing pediatric emergency physician.
+            <a href="about.html">Learn more about CloseDose →</a>
+          </p>
+        </div>
+
         <aside class="info-column" aria-label="How to use and safety reminders">
           <a class="cross-link-card" href="weighing-guide.html" aria-label="Open the weighing guide for infants and young children">
             <span class="cross-link-card__emoji" aria-hidden="true">⚖️</span>
@@ -104,15 +113,6 @@
             <p class="info-urgent-line">Any fever in a child <strong>under 2 months</strong> is a medical emergency — contact your pediatrician immediately.</p>
           </section>
         </aside>
-
-        <div class="calculator-column">
-          <div class="calculator-widget-host" id="calculator-card" data-calculator-root></div>
-
-          <p class="calculator-trust">
-            CloseDose is free, ad-free, and reviewed by an actively practicing pediatric emergency physician.
-            <a href="about.html">Learn more about CloseDose →</a>
-          </p>
-        </div>
       </div>
 
       <div class="layout layout--secondary">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace the two-column desktop grid layout (calculator + info side-by-side) with a single-column flex layout that scrolls cleanly on all screen sizes
- Narrow the content max-width from 1200px → 720px for a focused, readable centered column
- Reorder `index.html` so the calculator renders first, followed by info/safety cards below
- Tighten spacing (main padding, card gaps) for cleaner vertical rhythm
- Remove sticky calculator positioning and mobile `order` overrides — no longer needed with a unified single-column layout

## Test plan

- [ ] Open `index.html` in a browser — calculator should appear first, info cards scroll below it
- [ ] Resize from mobile to desktop — content stays single-column and centered at all widths
- [ ] Check other pages (about, medication-guides, dosing-guide, weighing-guide) — layout unaffected since they already used single-column `layout--inline`
- [ ] Verify no horizontal overflow at any viewport width

https://claude.ai/code/session_01UaMpSGXudBBNXThgS9AW5V
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaMpSGXudBBNXThgS9AW5V)_