### PR TITLE
Add system-aware dark/light mode with manual toggle

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -16,6 +16,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/about.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/contact.html
+++ b/public/contact.html
@@ -17,6 +17,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/contact.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="global.css" />
 
   <title>CloseDose Family Dashboard</title>
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/donations.html
+++ b/public/donations.html
@@ -17,6 +17,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/donations.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -17,6 +17,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/dosing-guide.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/global.css
+++ b/public/global.css
@@ -21,6 +21,64 @@
   --footer-muted: #a8b3bd;
   --footer-link: #4dd0e1;
   --footer-border: #1b263b;
+
+  /* Light/dark theme variables — light mode defaults */
+  --page-bg: #e8f5f0;
+  --page-overlay-start: rgba(205, 238, 226, 0.85);
+  --page-overlay-end: rgba(178, 218, 206, 0.9);
+  --hero-color: var(--ink-900);
+  --hero-eyebrow-color: rgba(15, 44, 42, 0.72);
+  --hero-sub-color: rgba(15, 44, 42, 0.78);
+  --hero-shadow: none;
+  --on-bg-muted: rgba(15, 44, 42, 0.65);
+  --on-bg-link: var(--teal-500);
+  --menu-overlay-bg: rgba(245, 249, 249, 0.98);
+  --menu-link-color: var(--ink-900);
+  --theme-toggle-bg: var(--white);
+  --theme-toggle-icon: '🌙';
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #0d2433;
+    --page-overlay-start: rgba(0, 0, 0, 0.85);
+    --page-overlay-end: rgba(24, 24, 24, 0.95);
+    --hero-color: #ffffff;
+    --hero-eyebrow-color: rgba(255, 255, 255, 0.78);
+    --hero-sub-color: rgba(255, 255, 255, 0.86);
+    --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
+    --on-bg-muted: rgba(255, 255, 255, 0.78);
+    --on-bg-link: var(--teal-400);
+    --menu-overlay-bg: rgba(245, 249, 249, 0.98);
+    --menu-link-color: var(--ink-900);
+    --theme-toggle-icon: '☀️';
+  }
+}
+
+html[data-theme="light"] {
+  --page-bg: #e8f5f0;
+  --page-overlay-start: rgba(205, 238, 226, 0.85);
+  --page-overlay-end: rgba(178, 218, 206, 0.9);
+  --hero-color: var(--ink-900);
+  --hero-eyebrow-color: rgba(15, 44, 42, 0.72);
+  --hero-sub-color: rgba(15, 44, 42, 0.78);
+  --hero-shadow: none;
+  --on-bg-muted: rgba(15, 44, 42, 0.65);
+  --on-bg-link: var(--teal-500);
+  --theme-toggle-icon: '🌙';
+}
+
+html[data-theme="dark"] {
+  --page-bg: #0d2433;
+  --page-overlay-start: rgba(0, 0, 0, 0.85);
+  --page-overlay-end: rgba(24, 24, 24, 0.95);
+  --hero-color: #ffffff;
+  --hero-eyebrow-color: rgba(255, 255, 255, 0.78);
+  --hero-sub-color: rgba(255, 255, 255, 0.86);
+  --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
+  --on-bg-muted: rgba(255, 255, 255, 0.78);
+  --on-bg-link: var(--teal-400);
+  --theme-toggle-icon: '☀️';
 }
 
 @keyframes slam-in {
@@ -37,15 +95,15 @@
 body {
   margin: 0;
   font-family: 'Inter', 'Nunito', system-ui, -apple-system, sans-serif;
-  background-color: #0d2433;
+  background-color: var(--page-bg);
   background-image:
-    linear-gradient(160deg, rgba(0, 0, 0, 0.85), rgba(24, 24, 24, 0.95)),
+    linear-gradient(160deg, var(--page-overlay-start), var(--page-overlay-end)),
     url('images/bg4k.png');
   background-size: auto, cover;
   background-repeat: no-repeat, no-repeat;
   background-position: center, center;
   background-attachment: fixed;
-  color: #0b2136;
+  color: var(--ink-900);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -191,7 +249,7 @@ main {
   font-weight: 800;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--hero-eyebrow-color);
 }
 
 .hero-title {
@@ -200,8 +258,8 @@ main {
   font-weight: 900;
   letter-spacing: -0.01em;
   line-height: 1.15;
-  color: #ffffff;
-  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
+  color: var(--hero-color);
+  text-shadow: var(--hero-shadow);
 }
 
 .hero-sub {
@@ -209,7 +267,7 @@ main {
   max-width: 60ch;
   font-size: clamp(1rem, 0.6vw + 0.85rem, 1.15rem);
   line-height: 1.55;
-  color: rgba(255, 255, 255, 0.86);
+  color: var(--hero-sub-color);
 }
 
 /* --- Layout: single-column scrolling --- */
@@ -246,11 +304,11 @@ main {
   text-align: center;
   font-size: 0.92rem;
   line-height: 1.5;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--on-bg-muted);
 }
 
 .calculator-trust a {
-  color: var(--teal-400);
+  color: var(--on-bg-link);
   font-weight: 700;
   text-decoration: none;
   white-space: nowrap;
@@ -624,8 +682,8 @@ main {
   font-weight: 900;
   letter-spacing: -0.01em;
   line-height: 1.15;
-  color: #ffffff;
-  text-shadow: 0 2px 18px rgba(0,0,0,0.35);
+  color: var(--hero-color);
+  text-shadow: var(--hero-shadow);
 }
 
 .guide-hero p {
@@ -633,7 +691,7 @@ main {
   max-width: 58ch;
   font-size: clamp(1rem, 0.6vw + 0.85rem, 1.12rem);
   line-height: 1.55;
-  color: rgba(255,255,255,0.84);
+  color: var(--hero-sub-color);
 }
 
 /* Medication article cards */
@@ -1492,18 +1550,37 @@ body.shopping-mode .formulation-card[data-product]::after {
   align-items: center;
   gap: 14px;
   padding: 14px 18px;
-  background: rgba(36,166,135,0.08);
-  border: 1px solid rgba(36,166,135,0.22);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1.5px solid rgba(36,166,135,0.42);
   border-radius: 14px;
   color: var(--ink-900);
   text-decoration: none;
+  box-shadow: 0 4px 16px rgba(36,166,135,0.14);
+  backdrop-filter: blur(12px);
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cross-link-card {
+    background: rgba(36,166,135,0.22);
+    border-color: rgba(36,166,135,0.45);
+  }
+}
+
+html[data-theme="dark"] .cross-link-card {
+  background: rgba(36,166,135,0.22);
+  border-color: rgba(36,166,135,0.45);
+}
+
+html[data-theme="light"] .cross-link-card {
+  background: rgba(255, 255, 255, 0.82);
+  border-color: rgba(36,166,135,0.42);
 }
 
 .cross-link-card:hover, .cross-link-card:focus-visible {
   transform: translateY(-1px);
-  background: rgba(36,166,135,0.12);
-  box-shadow: 0 8px 20px rgba(36,166,135,0.18);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 8px 24px rgba(36,166,135,0.22);
   outline: none;
 }
 
@@ -1916,8 +1993,25 @@ body.shopping-mode .formulation-card[data-product]::after {
 
 /* Secondary cross-link card (subtle teal tint) */
 .cross-link-card--secondary {
-  background: rgba(13,143,138,0.05);
-  border-color: rgba(13,143,138,0.2);
+  background: rgba(255, 255, 255, 0.76);
+  border-color: rgba(13,143,138,0.38);
+}
+
+@media (prefers-color-scheme: dark) {
+  .cross-link-card--secondary {
+    background: rgba(13,143,138,0.20);
+    border-color: rgba(13,143,138,0.4);
+  }
+}
+
+html[data-theme="dark"] .cross-link-card--secondary {
+  background: rgba(13,143,138,0.20);
+  border-color: rgba(13,143,138,0.4);
+}
+
+html[data-theme="light"] .cross-link-card--secondary {
+  background: rgba(255, 255, 255, 0.76);
+  border-color: rgba(13,143,138,0.38);
 }
 
 /* =============================================
@@ -1930,13 +2024,14 @@ body.shopping-mode .formulation-card[data-product]::after {
   font-weight: 900;
   line-height: 1.15;
   margin: 0 0 14px;
-  color: var(--ink-900);
+  color: var(--hero-color);
+  text-shadow: var(--hero-shadow);
 }
 
 .guide-hero p {
   font-size: clamp(1rem, 1vw + 0.8rem, 1.2rem);
   line-height: 1.6;
-  color: var(--ink-900);
+  color: var(--hero-sub-color);
   margin: 0;
 }
 
@@ -2074,4 +2169,65 @@ body.shopping-mode .formulation-card[data-product]::after {
   margin: 0;
   text-align: center;
   line-height: 1.5;
+}
+
+/* =============================================
+   THEME TOGGLE BUTTON
+   ============================================= */
+
+.theme-toggle {
+  appearance: none;
+  border: var(--card-border);
+  border-radius: 50%;
+  background: var(--white);
+  color: var(--ink-900);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--shadow-btn);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  position: fixed;
+  /* Desktop: sit to the left of the hamburger menu (top-right) */
+  top: clamp(16px, 3vw, 32px);
+  right: calc(clamp(18px, 5vw, 48px) + 56px + 14px);
+  z-index: 1200;
+  width: 48px;
+  height: 48px;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.theme-toggle:hover, .theme-toggle:focus-visible {
+  background: #f0faf6;
+  box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.theme-toggle:active {
+  transform: translateY(2px);
+  box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25);
+}
+
+/* On mobile the hamburger moves to bottom-left; keep toggle top-right */
+@media (max-width: 960px) {
+  .theme-toggle {
+    top: clamp(14px, 3vw, 28px);
+    right: clamp(16px, 5vw, 32px);
+    width: 44px;
+    height: 44px;
+    font-size: 1.1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .theme-toggle {
+    top: 12px;
+    right: 12px;
+    width: 40px;
+    height: 40px;
+    font-size: 1rem;
+  }
 }

--- a/public/global.js
+++ b/public/global.js
@@ -1,4 +1,46 @@
 (function () {
+  // --- Theme Management ---
+  const THEME_KEY = 'cd-theme';
+
+  function getEffectiveTheme() {
+    const saved = localStorage.getItem(THEME_KEY);
+    if (saved) return saved;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function applyTheme(theme, save) {
+    document.documentElement.setAttribute('data-theme', theme);
+    if (save) localStorage.setItem(THEME_KEY, theme);
+    const btn = document.querySelector('.theme-toggle');
+    if (btn) {
+      btn.textContent = theme === 'dark' ? '☀️' : '🌙';
+      btn.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    }
+  }
+
+  // Inject theme toggle button and wire up click
+  document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.createElement('button');
+    toggle.className = 'theme-toggle';
+    toggle.type = 'button';
+    const currentTheme = getEffectiveTheme();
+    toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
+    toggle.setAttribute('aria-label', currentTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    document.body.appendChild(toggle);
+
+    toggle.addEventListener('click', function () {
+      const active = document.documentElement.getAttribute('data-theme') || getEffectiveTheme();
+      applyTheme(active === 'dark' ? 'light' : 'dark', true);
+    });
+
+    // Sync if system preference changes and no manual override is stored
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+      if (!localStorage.getItem(THEME_KEY)) {
+        applyTheme(e.matches ? 'dark' : 'light', false);
+      }
+    });
+  });
+
   // --- Site Menu Logic ---
   const menuButton = document.querySelector('.menu-btn');
   const overlay = document.getElementById('siteMenu');

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
     gtag('config', 'G-WYY1QFRPYP');
   </script>
   <link rel="stylesheet" href="global.css" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <a class="skip-link" href="#calculator-card">Skip to calculator</a>

--- a/public/login.html
+++ b/public/login.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="global.css" />
 
   <title>CloseDose Login</title>
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -17,6 +17,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/medication-guides.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -17,6 +17,7 @@
   <meta property="og:image" content="https://closedose.com/images/favicon-192.png" />
   <meta property="og:url" content="https://closedose.com/weighing-guide.html" />
   <meta name="twitter:card" content="summary" />
+  <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
 <body>
   <div class="wrap">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **System-aware theming**: Site automatically uses light or dark styling based on the user's OS/browser `prefers-color-scheme` setting by default
- **Manual toggle**: A fixed ☀️/🌙 button (top-right corner on desktop and mobile) lets users override their system setting; choice is persisted in `localStorage`
- **FOUC prevention**: A tiny inline `<script>` in each page's `<head>` reads the stored preference and sets `data-theme` before the first paint, eliminating flash-of-wrong-theme
- **Cross-link card visibility**: The weighing guide and dosing guide link boxes on the index page are significantly less transparent — now use ~80% opaque white (light mode) or ~22% teal (dark mode) backgrounds with stronger borders and a box-shadow

## Technical details

- New CSS variables (`--page-bg`, `--hero-color`, `--hero-sub-color`, `--on-bg-muted`, etc.) added to `:root` with light-mode defaults
- `@media (prefers-color-scheme: dark)` overrides the variables for dark mode
- `html[data-theme="light"]` and `html[data-theme="dark"]` attribute selectors allow the toggle to override the media query (higher specificity)
- Theme toggle button injected via `global.js` on `DOMContentLoaded`; also listens for system preference changes when no manual override is stored
- All 9 main HTML pages updated with FOUC-prevention script

## Test plan

- [ ] Visit site with OS in light mode — background should be light teal/green, hero text should be dark
- [ ] Visit site with OS in dark mode — background should be dark blue, hero text should be white
- [ ] Click the ☀️/🌙 toggle to manually switch; reload page and confirm preference persists
- [ ] Confirm toggle button does not overlap calculator, Cappy button, or hamburger menu on desktop and mobile
- [ ] Confirm weighing guide and dosing guide cards on index are clearly visible in both modes
- [ ] Check guide pages (weighing-guide, dosing-guide, medication-guides) for readable hero text in both modes

https://claude.ai/code/session_0191in9MpgGLJYbmTgzkuqro
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191in9MpgGLJYbmTgzkuqro)_