### PR TITLE
Improve dark mode aesthetics, System/Day/Night toggle, fix Cappy image paths

### DIFF
--- a/public/EnteralID.html
+++ b/public/EnteralID.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>EnteralID | Pediatric Enteral Device Guide</title>
+<script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>

--- a/public/about.html
+++ b/public/about.html
@@ -32,7 +32,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="Cappy Logo" />
+      <img src="images/cappy_circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -196,7 +196,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/contact.html
+++ b/public/contact.html
@@ -33,7 +33,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="" />
+      <img src="images/cappy_circle.png" alt="" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -145,7 +145,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -24,7 +24,7 @@
       </button>
     </header>
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="Cappy Logo" />
+      <img src="images/cappy_circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>

--- a/public/donations.html
+++ b/public/donations.html
@@ -33,7 +33,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="" />
+      <img src="images/cappy_circle.png" alt="" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -151,7 +151,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -33,7 +33,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="" />
+      <img src="images/cappy_circle.png" alt="" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -505,7 +505,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/global.css
+++ b/public/global.css
@@ -40,18 +40,20 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --page-bg: #0d2433;
-    --page-overlay-start: rgba(0, 0, 0, 0.85);
-    --page-overlay-end: rgba(24, 24, 24, 0.95);
+    --page-bg: #111827;
+    --page-overlay-start: rgba(10, 15, 25, 0.78);
+    --page-overlay-end: rgba(17, 24, 39, 0.88);
     --hero-color: #ffffff;
     --hero-eyebrow-color: rgba(255, 255, 255, 0.78);
     --hero-sub-color: rgba(255, 255, 255, 0.86);
     --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
     --on-bg-muted: rgba(255, 255, 255, 0.78);
     --on-bg-link: var(--teal-400);
-    --menu-overlay-bg: rgba(245, 249, 249, 0.98);
-    --menu-link-color: var(--ink-900);
+    --menu-overlay-bg: rgba(13, 18, 30, 0.98);
+    --menu-link-color: #e2e8f0;
     --theme-toggle-icon: '☀️';
+    --card-bg: rgba(255, 255, 255, 0.97);
+    --card-border: 1px solid rgba(255, 255, 255, 0.18);
   }
 }
 
@@ -69,16 +71,20 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
-  --page-bg: #0d2433;
-  --page-overlay-start: rgba(0, 0, 0, 0.85);
-  --page-overlay-end: rgba(24, 24, 24, 0.95);
+  --page-bg: #111827;
+  --page-overlay-start: rgba(10, 15, 25, 0.78);
+  --page-overlay-end: rgba(17, 24, 39, 0.88);
   --hero-color: #ffffff;
   --hero-eyebrow-color: rgba(255, 255, 255, 0.78);
   --hero-sub-color: rgba(255, 255, 255, 0.86);
   --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
   --on-bg-muted: rgba(255, 255, 255, 0.78);
   --on-bg-link: var(--teal-400);
+  --menu-overlay-bg: rgba(13, 18, 30, 0.98);
+  --menu-link-color: #e2e8f0;
   --theme-toggle-icon: '☀️';
+  --card-bg: rgba(255, 255, 255, 0.97);
+  --card-border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 @keyframes slam-in {
@@ -2230,4 +2236,210 @@ html[data-theme="light"] .cross-link-card--secondary {
     height: 40px;
     font-size: 1rem;
   }
+}
+
+/* =============================================
+   DARK MODE — GUIDE CARDS & STEP BOXES
+   ============================================= */
+
+/* Step cards: boost opacity in dark mode so text stays crisp */
+@media (prefers-color-scheme: dark) {
+  .step-card {
+    background: rgba(255, 255, 255, 0.93);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+  .tare-alt {
+    background: rgba(255, 200, 100, 0.12);
+    border-color: rgba(255, 192, 56, 0.4);
+  }
+  .tip-card {
+    background: rgba(13, 143, 138, 0.14);
+    border-color: rgba(36, 166, 135, 0.38);
+  }
+}
+
+html[data-theme="dark"] .step-card {
+  background: rgba(255, 255, 255, 0.93);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+html[data-theme="dark"] .tare-alt {
+  background: rgba(255, 200, 100, 0.12);
+  border-color: rgba(255, 192, 56, 0.4);
+}
+
+html[data-theme="dark"] .tip-card {
+  background: rgba(13, 143, 138, 0.14);
+  border-color: rgba(36, 166, 135, 0.38);
+}
+
+html[data-theme="light"] .step-card {
+  background: rgba(255, 255, 255, 0.65);
+  border-color: rgba(15, 44, 42, 0.08);
+}
+
+/* Dose marking cards (dosing guide) */
+@media (prefers-color-scheme: dark) {
+  .dose-marking-card--correct {
+    background: rgba(22, 163, 74, 0.14);
+  }
+  .dose-marking-card--wrong {
+    background: rgba(220, 38, 38, 0.12);
+  }
+}
+html[data-theme="dark"] .dose-marking-card--correct { background: rgba(22, 163, 74, 0.14); }
+html[data-theme="dark"] .dose-marking-card--wrong   { background: rgba(220, 38, 38, 0.12); }
+
+/* =============================================
+   DARK MODE — MENU OVERLAY
+   ============================================= */
+
+@media (prefers-color-scheme: dark) {
+  .menu-overlay {
+    background: rgba(13, 18, 30, 0.98);
+  }
+  .menu-links a {
+    color: #e2e8f0;
+  }
+  .menu-links a[aria-current="page"] {
+    color: var(--teal-400);
+  }
+  .close-menu {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.14);
+    color: #e2e8f0;
+  }
+  .close-menu:hover {
+    background: rgba(255, 255, 255, 0.14);
+  }
+}
+
+html[data-theme="dark"] .menu-overlay {
+  background: rgba(13, 18, 30, 0.98);
+}
+html[data-theme="dark"] .menu-links a {
+  color: #e2e8f0;
+}
+html[data-theme="dark"] .menu-links a[aria-current="page"] {
+  color: var(--teal-400);
+}
+html[data-theme="dark"] .close-menu {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: #e2e8f0;
+}
+html[data-theme="dark"] .close-menu:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+html[data-theme="light"] .menu-overlay  { background: rgba(245, 249, 249, 0.98); }
+html[data-theme="light"] .menu-links a  { color: var(--ink-900); }
+html[data-theme="light"] .close-menu    { background: var(--white); color: var(--ink-900); }
+
+/* =============================================
+   MENU THEME PICKER (System / Day / Night)
+   ============================================= */
+
+.menu-theme-picker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+}
+
+.menu-theme-label {
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--on-bg-muted);
+}
+
+.menu-theme-options {
+  display: flex;
+  gap: 8px;
+}
+
+.menu-theme-btn {
+  appearance: none;
+  border: 1px solid rgba(15, 44, 42, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink-900);
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 7px 16px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: none;
+}
+
+.menu-theme-btn:hover {
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 2px 8px rgba(15, 44, 42, 0.12);
+}
+
+.menu-theme-btn.is-active {
+  background: var(--ink-900);
+  color: #fff;
+  border-color: var(--ink-900);
+  box-shadow: 0 3px 10px rgba(15, 44, 42, 0.28);
+}
+
+/* Dark mode picker styles */
+@media (prefers-color-scheme: dark) {
+  .menu-theme-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.16);
+    color: #e2e8f0;
+  }
+  .menu-theme-btn:hover {
+    background: rgba(255, 255, 255, 0.14);
+  }
+  .menu-theme-btn.is-active {
+    background: var(--teal-400);
+    border-color: var(--teal-400);
+    color: #fff;
+    box-shadow: 0 3px 10px rgba(36, 166, 135, 0.4);
+  }
+  .menu-theme-label {
+    color: rgba(255, 255, 255, 0.6);
+  }
+}
+
+html[data-theme="dark"] .menu-theme-btn {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #e2e8f0;
+}
+html[data-theme="dark"] .menu-theme-btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+html[data-theme="dark"] .menu-theme-btn.is-active {
+  background: var(--teal-400);
+  border-color: var(--teal-400);
+  color: #fff;
+  box-shadow: 0 3px 10px rgba(36, 166, 135, 0.4);
+}
+html[data-theme="dark"] .menu-theme-label {
+  color: rgba(255, 255, 255, 0.6);
+}
+html[data-theme="light"] .menu-theme-btn {
+  background: rgba(255, 255, 255, 0.72);
+  border-color: rgba(15, 44, 42, 0.18);
+  color: var(--ink-900);
+}
+html[data-theme="light"] .menu-theme-btn.is-active {
+  background: var(--ink-900);
+  border-color: var(--ink-900);
+  color: #fff;
+}
+
+/* Mobile: keep theme picker compact */
+@media (max-width: 480px) {
+  .menu-theme-btn { padding: 6px 12px; font-size: 0.72rem; }
 }

--- a/public/global.js
+++ b/public/global.js
@@ -1,42 +1,91 @@
 (function () {
   // --- Theme Management ---
+  // Stored values: 'light' | 'dark' | absent (means "system")
   const THEME_KEY = 'cd-theme';
 
+  function getStoredChoice() {
+    return localStorage.getItem(THEME_KEY); // 'light' | 'dark' | null
+  }
+
   function getEffectiveTheme() {
-    const saved = localStorage.getItem(THEME_KEY);
-    if (saved) return saved;
+    const stored = getStoredChoice();
+    if (stored === 'light' || stored === 'dark') return stored;
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  function applyTheme(theme, save) {
-    document.documentElement.setAttribute('data-theme', theme);
-    if (save) localStorage.setItem(THEME_KEY, theme);
-    const btn = document.querySelector('.theme-toggle');
-    if (btn) {
-      btn.textContent = theme === 'dark' ? '☀️' : '🌙';
-      btn.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+  // choice: 'system' | 'light' | 'dark'
+  function applyTheme(choice) {
+    if (choice === 'system') {
+      localStorage.removeItem(THEME_KEY);
+      const effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', effective);
+    } else {
+      localStorage.setItem(THEME_KEY, choice);
+      document.documentElement.setAttribute('data-theme', choice);
     }
+    updateThemeUI();
+  }
+
+  function updateThemeUI() {
+    const stored = getStoredChoice();
+    const activeChoice = stored || 'system';
+    const effective = getEffectiveTheme();
+
+    // Floating quick-toggle icon
+    const floatBtn = document.querySelector('.theme-toggle');
+    if (floatBtn) {
+      floatBtn.textContent = effective === 'dark' ? '☀️' : '🌙';
+      floatBtn.setAttribute('aria-label', effective === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    }
+
+    // Menu picker active states
+    document.querySelectorAll('.menu-theme-btn').forEach(b => {
+      const isActive = b.dataset.themeChoice === activeChoice;
+      b.classList.toggle('is-active', isActive);
+      b.setAttribute('aria-pressed', String(isActive));
+    });
   }
 
   // Inject theme toggle button and wire up click
   document.addEventListener('DOMContentLoaded', function () {
+    // Floating quick-toggle (top-right on desktop, top-right on mobile)
     const toggle = document.createElement('button');
     toggle.className = 'theme-toggle';
     toggle.type = 'button';
-    const currentTheme = getEffectiveTheme();
-    toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
-    toggle.setAttribute('aria-label', currentTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
     document.body.appendChild(toggle);
 
     toggle.addEventListener('click', function () {
-      const active = document.documentElement.getAttribute('data-theme') || getEffectiveTheme();
-      applyTheme(active === 'dark' ? 'light' : 'dark', true);
+      const effective = getEffectiveTheme();
+      applyTheme(effective === 'dark' ? 'light' : 'dark');
     });
 
-    // Sync if system preference changes and no manual override is stored
+    // Inject System / Day / Night picker into the menu panel
+    const menuPanel = document.querySelector('.menu-panel');
+    if (menuPanel) {
+      const picker = document.createElement('div');
+      picker.className = 'menu-theme-picker';
+      picker.innerHTML =
+        '<p class="menu-theme-label">Appearance</p>' +
+        '<div class="menu-theme-options" role="group" aria-label="Appearance">' +
+          '<button type="button" class="menu-theme-btn" data-theme-choice="system" aria-pressed="false">System</button>' +
+          '<button type="button" class="menu-theme-btn" data-theme-choice="light" aria-pressed="false">Day</button>' +
+          '<button type="button" class="menu-theme-btn" data-theme-choice="dark" aria-pressed="false">Night</button>' +
+        '</div>';
+      const closeBtn = menuPanel.querySelector('.close-menu');
+      menuPanel.insertBefore(picker, closeBtn);
+
+      picker.querySelectorAll('.menu-theme-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () { applyTheme(btn.dataset.themeChoice); });
+      });
+    }
+
+    updateThemeUI();
+
+    // Sync when OS preference changes and no manual override is stored
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-      if (!localStorage.getItem(THEME_KEY)) {
-        applyTheme(e.matches ? 'dark' : 'light', false);
+      if (!getStoredChoice()) {
+        document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+        updateThemeUI();
       }
     });
   });

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="" />
+      <img src="images/cappy_circle.png" alt="" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -190,7 +190,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/login.html
+++ b/public/login.html
@@ -24,7 +24,7 @@
       </button>
     </header>
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="Cappy Logo" />
+      <img src="images/cappy_circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -33,7 +33,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="Cappy Logo" />
+      <img src="images/cappy_circle.png" alt="Cappy Logo" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -530,7 +530,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -33,7 +33,7 @@
     </header>
 
     <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="cappy/assets/cappy_circle.png" alt="" />
+      <img src="images/cappy_circle.png" alt="" />
       <div class="cappy-waitlist-content">
         <span class="cappy-waitlist-brand">Cappy!</span>
         <span class="cappy-waitlist-tagline">Join the waitlist today</span>
@@ -273,7 +273,7 @@
   <div id="cappyWaitlistModal" class="cappy-modal-overlay" aria-hidden="true">
     <div class="cappy-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="cappyWaitlistTitle">
       <button class="cappy-modal-close" aria-label="Close waitlist dialog">&times;</button>
-      <div class="cappy-badge"><img src="cappy/assets/cappy_circle.png" alt="" /></div>
+      <div class="cappy-badge"><img src="images/cappy_circle.png" alt="" /></div>
       <h2 id="cappyWaitlistTitle">Cappy is coming soon!</h2>
       <p>Join the waitlist to get early access.</p>
       <form id="waitlistForm" class="cappy-waitlist-form">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Dark mode background**: Replaced the harsh cold navy (`#0d2433`) with a softer charcoal-slate (`#111827`) — less jarring when scrolling to page edges
- **Guide card visibility**: Step cards in the weighing and dosing guides boosted from 65% to 93% opacity in dark mode so text is crisp and readable; tip cards and tare-alt widget also improved
- **Menu dark mode**: Menu overlay, nav links, and Close button now render correctly in dark mode (was showing a white overlay on a dark page)
- **System/Day/Night theme toggle**: Replaced binary light/dark toggle with a three-way picker injected into the hamburger menu by `global.js` — no per-page HTML edits needed. Floating ☀️/🌙 quick-toggle remains and stays in sync. Storing `'light'` or `'dark'` in `localStorage`; absent key = follow system.
- **Cappy image path**: All 16 references to `cappy/assets/cappy_circle.png` updated to `images/cappy_circle.png` (the canonical source file)
- **Session consistency**: Added `localStorage` theme-init script to `EnteralID.html` so it also respects the saved preference on load

## Test plan

- [ ] Open site in a browser with system dark mode → page background should be `#111827` charcoal, not cold navy
- [ ] Open hamburger menu → see **Appearance / System / Day / Night** picker; selecting each should change theme immediately and persist on reload
- [ ] Floating ☀️/🌙 button still toggles between light and dark and updates picker active state
- [ ] Visit weighing-guide.html and dosing-guide.html in dark mode → step cards should be clearly legible (near-opaque white background)
- [ ] Confirm Cappy floating button image loads on all pages (index, about, contact, donations, weighing-guide, dosing-guide, medication-guides, login, dashboard)
- [ ] Reload page after selecting Night → stays Night; reload after selecting System → follows OS

https://claude.ai/code/session_019t6mE5efPeVwHZ56uG78At
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6mE5efPeVwHZ56uG78At)_