### PR TITLE
Redesign weigh guide: new animation, collapsible calculator, animated menu toggle

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -1428,106 +1428,231 @@ body.shopping-mode .formulation-card[data-product]::after {
 .step-card__title { margin: 0; font-size: 0.95rem; font-weight: 900; color: var(--ink-900); line-height: 1.25; }
 .step-card__text { margin: 0; font-size: 0.85rem; line-height: 1.45; color: var(--ink-900); }
 
-/* Subtraction calculator widget (no-tare alternative) */
-.tare-alt {
-  background: rgba(255, 200, 100, 0.08);
-  border: 1px solid rgba(255, 192, 56, 0.3);
-  border-radius: 12px;
-  padding: 16px 18px;
+/* Animated SVG on weighing guide */
+.tare-anim-img {
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+  display: block;
+}
+
+/* No-tare toggle button */
+.tare-alt-wrapper {
   margin: 0 0 24px;
 }
 
-.tare-alt[open] { padding-bottom: 20px; }
-
-.tare-alt summary {
-  cursor: pointer;
-  font-weight: 800;
-  color: var(--ink-900);
-  font-size: 0.92rem;
-  list-style: none;
+.no-tare-btn {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 18px;
+  background: rgba(255, 200, 100, 0.1);
+  border: 1.5px solid rgba(255, 192, 56, 0.35);
+  border-radius: 12px;
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 800;
+  color: var(--ink-900);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease, border-radius 0.2s ease;
 }
 
-.tare-alt summary::-webkit-details-marker { display: none; }
-.tare-alt summary::before {
+.no-tare-btn::before {
   content: '+';
   display: inline-grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
   border-radius: 50%;
-  background: rgba(255, 192, 56, 0.35);
+  background: rgba(255, 192, 56, 0.4);
   color: var(--ink-900);
   font-weight: 900;
   font-size: 1rem;
   transition: transform 0.2s ease;
 }
 
-.tare-alt[open] summary::before { content: '−'; }
-
-.tare-alt p, .tare-alt ol { margin: 12px 0 0; line-height: 1.55; font-size: 0.9rem; color: var(--ink-900); }
-.tare-alt ol { padding-left: 1.2rem; display: grid; gap: 4px; }
-
-.tare-calc {
-  display: grid;
-  gap: 12px;
-  margin-top: 16px;
+.no-tare-btn[aria-expanded="true"] {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-color: transparent;
 }
 
-@media (min-width: 600px) { .tare-calc { grid-template-columns: 1fr 1fr; } }
+.no-tare-btn[aria-expanded="true"]::before {
+  content: '−';
+}
 
-.tare-calc label {
+.no-tare-btn:hover {
+  background: rgba(255, 200, 100, 0.18);
+  border-color: rgba(255, 192, 56, 0.55);
+}
+
+/* Subtraction calculator card (calculator-style) */
+.subtraction-calc-card {
+  border: 1.5px solid rgba(255, 192, 56, 0.35);
+  border-top: none;
+  border-radius: 0 0 14px 14px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(15, 44, 42, 0.1);
+  margin-bottom: 0;
+}
+
+.subtraction-calc {
+  background: #18232f;
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+}
+
+.subtraction-calc__header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: #111b25;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.subtraction-calc__header-icon {
+  font-size: 1rem;
+  font-weight: 900;
+  color: rgba(255, 192, 56, 0.7);
+  line-height: 1;
+}
+
+.subtraction-calc__header-title {
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+
+.subtraction-calc__screen {
+  padding: 18px 20px 14px;
+  background: #0c1520;
+  text-align: right;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 4px;
+  min-height: 76px;
+}
+
+.subtraction-calc__screen-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(36, 166, 135, 0.65);
+}
+
+.subtraction-calc__screen-val {
+  font-family: 'Courier New', monospace;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.subtraction-calc__screen-val--placeholder { color: rgba(255,255,255,0.2); }
+.subtraction-calc__screen-val--result      { color: #22c55e; }
+.subtraction-calc__screen-val--error       { color: #ef4444; font-size: 1.4rem; }
+
+.subtraction-calc__keys {
+  padding: 18px 18px 20px;
   display: grid;
   gap: 6px;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-muted);
 }
 
-.tare-calc input {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 100%;
-  padding: 12px 14px;
-  border: 2px solid rgba(15,44,42,0.18);
-  border-radius: 10px;
-  background: #fff;
-  font-family: inherit;
-  font-size: 1rem;
+.subtraction-calc__field {
+  display: grid;
+  gap: 5px;
+}
+
+.subtraction-calc__field-label {
+  font-size: 0.7rem;
   font-weight: 700;
-  color: var(--ink-900);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+
+.subtraction-calc__field-row {
+  display: flex;
+  align-items: center;
+  background: rgba(255,255,255,0.07);
+  border: 1.5px solid rgba(255,255,255,0.1);
+  border-radius: 10px;
+  overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.tare-calc input:focus {
-  outline: none;
+.subtraction-calc__field-row:focus-within {
   border-color: var(--teal-400);
-  box-shadow: 0 0 0 4px rgba(36,166,135,0.15);
+  box-shadow: 0 0 0 3px rgba(36, 166, 135, 0.18);
 }
 
-.tare-calc__result {
-  grid-column: 1 / -1;
-  padding: 14px 16px;
-  background: rgba(255,255,255,0.7);
-  border-radius: 10px;
-  font-size: 0.95rem;
-  color: var(--text-muted);
-  text-align: center;
-  font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.tare-calc__result.has-result {
-  background: rgba(36,166,135,0.12);
-  color: var(--teal-600);
+.subtraction-calc__field-row input {
+  appearance: none;
+  -webkit-appearance: none;
+  flex: 1;
+  padding: 11px 14px;
+  background: transparent;
+  border: none;
+  font-family: 'Courier New', monospace;
+  font-size: 1.15rem;
   font-weight: 700;
+  color: #fff;
+  outline: none;
+  min-width: 0;
 }
 
-.tare-calc__result strong { color: var(--ink-900); font-size: 1.15rem; font-weight: 900; }
+.subtraction-calc__field-row input::placeholder {
+  color: rgba(255,255,255,0.18);
+}
+
+.subtraction-calc__unit {
+  padding: 0 14px 0 6px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: rgba(255,255,255,0.3);
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.subtraction-calc__op {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 16px;
+  font-size: 1.6rem;
+  font-weight: 900;
+  color: rgba(255,255,255,0.22);
+  line-height: 1;
+  margin: -2px 0;
+  user-select: none;
+}
+
+.subtraction-calc__error {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fca5a5;
+  line-height: 1.4;
+}
+
+/* Dark mode overrides for no-tare btn */
+@media (prefers-color-scheme: dark) {
+  .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
+}
+html[data-theme="dark"] .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
 
 /* Tip card on weighing page */
 .tip-card {
@@ -2178,79 +2303,107 @@ html[data-theme="light"] .cross-link-card--secondary {
 }
 
 /* =============================================
-   THEME TOGGLE BUTTON
+   ANIMATED DAY / NIGHT TOGGLE (menu)
    ============================================= */
 
-.theme-toggle {
-  appearance: none;
-  border: var(--card-border);
-  border-radius: 50%;
-  background: var(--white);
-  color: var(--ink-900);
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.theme-toggle-wrapper {
+  width: 160px;
+  height: 64px;
+  border-radius: 999px;
+  position: relative;
   cursor: pointer;
-  box-shadow: var(--shadow-btn);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
-  position: fixed;
-  /* Desktop: sit to the left of the hamburger menu (top-right) */
-  top: clamp(16px, 3vw, 32px);
-  right: calc(clamp(18px, 5vw, 48px) + 56px + 14px);
-  z-index: 1200;
-  width: 48px;
-  height: 48px;
-  font-size: 1.2rem;
-  line-height: 1;
+  overflow: hidden;
+  box-shadow: 0 6px 14px rgba(0,0,0,0.12), inset 0 3px 8px rgba(0,0,0,0.22);
+  border: 3px solid #ffffff;
+  display: inline-block;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.6s ease, box-shadow 0.6s ease;
 }
 
-.theme-toggle:hover, .theme-toggle:focus-visible {
-  background: #f0faf6;
-  box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35);
-  outline: none;
-  transform: translateY(-1px);
+.theme-toggle-wrapper:has(input:checked) {
+  border-color: #0f172a;
+  box-shadow: 0 6px 14px rgba(0,0,0,0.45), inset 0 3px 8px rgba(0,0,0,0.35);
 }
 
-.theme-toggle:active {
-  transform: translateY(2px);
-  box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25);
+.theme-toggle-wrapper input {
+  display: none;
 }
 
-/* On mobile the hamburger moves to bottom-left; keep toggle top-right */
-@media (max-width: 960px) {
-  .theme-toggle {
-    top: clamp(14px, 3vw, 28px);
-    right: clamp(16px, 5vw, 32px);
-    width: 44px;
-    height: 44px;
-    font-size: 1.1rem;
-  }
+.toggle-bg-day,
+.toggle-bg-night {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  transition: opacity 0.6s ease, transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-@media (max-width: 640px) {
-  .theme-toggle {
-    top: 12px;
-    right: 12px;
-    width: 40px;
-    height: 40px;
-    font-size: 1rem;
-  }
+.toggle-bg-night {
+  opacity: 0;
+  transform: translateY(-18px);
+}
+
+input:checked ~ .toggle-bg-day {
+  opacity: 0;
+  transform: translateY(18px);
+}
+
+input:checked ~ .toggle-bg-night {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background-color: #f6c83b;
+  box-shadow: inset -4px -4px 8px rgba(0,0,0,0.15), 0 4px 8px rgba(0,0,0,0.2);
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background-color 0.6s ease,
+              box-shadow 0.6s ease;
+  z-index: 10;
+}
+
+/* 160px - 54px knob - 10px total margin = 96px travel */
+input:checked ~ .toggle-knob {
+  transform: translateX(96px);
+  background-color: #c1c8d4;
+  box-shadow: inset -4px -4px 8px rgba(0,0,0,0.3), 0 4px 8px rgba(0,0,0,0.25);
+}
+
+.crater {
+  position: absolute;
+  background-color: #a3acb9;
+  border-radius: 50%;
+  box-shadow: inset 2px 2px 4px rgba(0,0,0,0.2);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.crater-1 { width: 12px; height: 12px; top: 12px; left: 28px; }
+.crater-2 { width: 9px;  height: 9px;  top: 30px; left: 14px; }
+.crater-3 { width: 7px;  height: 7px;  top: 34px; left: 32px; }
+
+input:checked ~ .toggle-knob .crater {
+  opacity: 1;
+  transition-delay: 0.2s;
 }
 
 /* =============================================
    DARK MODE — GUIDE CARDS & STEP BOXES
    ============================================= */
 
-/* Step cards: boost opacity in dark mode so text stays crisp */
+/* Dark mode overrides for weighing guide elements */
 @media (prefers-color-scheme: dark) {
-  .step-card {
-    background: rgba(255, 255, 255, 0.93);
-    border-color: rgba(255, 255, 255, 0.2);
-  }
-  .tare-alt {
-    background: rgba(255, 200, 100, 0.12);
-    border-color: rgba(255, 192, 56, 0.4);
+  .no-tare-btn {
+    background: rgba(255, 200, 100, 0.08);
+    border-color: rgba(255, 192, 56, 0.35);
   }
   .tip-card {
     background: rgba(13, 143, 138, 0.14);
@@ -2258,24 +2411,14 @@ html[data-theme="light"] .cross-link-card--secondary {
   }
 }
 
-html[data-theme="dark"] .step-card {
-  background: rgba(255, 255, 255, 0.93);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-html[data-theme="dark"] .tare-alt {
-  background: rgba(255, 200, 100, 0.12);
-  border-color: rgba(255, 192, 56, 0.4);
+html[data-theme="dark"] .no-tare-btn {
+  background: rgba(255, 200, 100, 0.08);
+  border-color: rgba(255, 192, 56, 0.35);
 }
 
 html[data-theme="dark"] .tip-card {
   background: rgba(13, 143, 138, 0.14);
   border-color: rgba(36, 166, 135, 0.38);
-}
-
-html[data-theme="light"] .step-card {
-  background: rgba(255, 255, 255, 0.65);
-  border-color: rgba(15, 44, 42, 0.08);
 }
 
 /* Dose marking cards (dosing guide) */
@@ -2343,7 +2486,7 @@ html[data-theme="light"] .close-menu    { background: var(--white); color: var(-
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 14px;
   margin-bottom: 28px;
 }
 
@@ -2356,11 +2499,7 @@ html[data-theme="light"] .close-menu    { background: var(--white); color: var(-
   color: var(--on-bg-muted);
 }
 
-.menu-theme-options {
-  display: flex;
-  gap: 8px;
-}
-
+/* System/auto button below the animated toggle */
 .menu-theme-btn {
   appearance: none;
   border: 1px solid rgba(15, 44, 42, 0.18);
@@ -2368,11 +2507,11 @@ html[data-theme="light"] .close-menu    { background: var(--white); color: var(-
   background: rgba(255, 255, 255, 0.72);
   color: var(--ink-900);
   font-family: inherit;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 7px 16px;
+  padding: 6px 18px;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
   box-shadow: none;
@@ -2437,9 +2576,4 @@ html[data-theme="light"] .menu-theme-btn.is-active {
   background: var(--ink-900);
   border-color: var(--ink-900);
   color: #fff;
-}
-
-/* Mobile: keep theme picker compact */
-@media (max-width: 480px) {
-  .menu-theme-btn { padding: 6px 12px; font-size: 0.72rem; }
 }

--- a/public/global.js
+++ b/public/global.js
@@ -31,14 +31,13 @@
     const activeChoice = stored || 'system';
     const effective = getEffectiveTheme();
 
-    // Floating quick-toggle icon
-    const floatBtn = document.querySelector('.theme-toggle');
-    if (floatBtn) {
-      floatBtn.textContent = effective === 'dark' ? '☀️' : '🌙';
-      floatBtn.setAttribute('aria-label', effective === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    // Animated toggle checkbox in the menu
+    const themeSwitch = document.getElementById('menu-theme-switch');
+    if (themeSwitch) {
+      themeSwitch.checked = effective === 'dark';
     }
 
-    // Menu picker active states
+    // System button active state
     document.querySelectorAll('.menu-theme-btn').forEach(b => {
       const isActive = b.dataset.themeChoice === activeChoice;
       b.classList.toggle('is-active', isActive);
@@ -46,33 +45,54 @@
     });
   }
 
-  // Inject theme toggle button and wire up click
+  // Inject theme toggle and wire up click
   document.addEventListener('DOMContentLoaded', function () {
-    // Floating quick-toggle (top-right on desktop, top-right on mobile)
-    const toggle = document.createElement('button');
-    toggle.className = 'theme-toggle';
-    toggle.type = 'button';
-    document.body.appendChild(toggle);
-
-    toggle.addEventListener('click', function () {
-      const effective = getEffectiveTheme();
-      applyTheme(effective === 'dark' ? 'light' : 'dark');
-    });
-
-    // Inject System / Day / Night picker into the menu panel
+    // Inject animated Day/Night toggle + System button into the menu panel
     const menuPanel = document.querySelector('.menu-panel');
     if (menuPanel) {
       const picker = document.createElement('div');
       picker.className = 'menu-theme-picker';
       picker.innerHTML =
         '<p class="menu-theme-label">Appearance</p>' +
-        '<div class="menu-theme-options" role="group" aria-label="Appearance">' +
-          '<button type="button" class="menu-theme-btn" data-theme-choice="system" aria-pressed="false">System</button>' +
-          '<button type="button" class="menu-theme-btn" data-theme-choice="light" aria-pressed="false">Day</button>' +
-          '<button type="button" class="menu-theme-btn" data-theme-choice="dark" aria-pressed="false">Night</button>' +
-        '</div>';
+        '<label class="theme-toggle-wrapper" for="menu-theme-switch" aria-label="Toggle dark mode">' +
+          '<input type="checkbox" id="menu-theme-switch">' +
+          '<svg class="toggle-bg-day" viewBox="0 0 180 72" preserveAspectRatio="none">' +
+            '<rect width="180" height="72" fill="#74a1d3"/>' +
+            '<circle cx="36" cy="36" r="45" fill="#8bb3de"/>' +
+            '<circle cx="36" cy="36" r="70" fill="#9ebfe5"/>' +
+            '<circle cx="36" cy="36" r="95" fill="#b0cbec"/>' +
+            '<g fill="#e3f0fa"><circle cx="15" cy="76" r="24"/><circle cx="65" cy="74" r="30"/><circle cx="115" cy="76" r="26"/><circle cx="165" cy="74" r="32"/></g>' +
+            '<g fill="#ffffff"><circle cx="10" cy="80" r="24"/><circle cx="55" cy="80" r="30"/><circle cx="105" cy="80" r="26"/><circle cx="155" cy="80" r="32"/><circle cx="190" cy="80" r="24"/></g>' +
+          '</svg>' +
+          '<svg class="toggle-bg-night" viewBox="0 0 180 72" preserveAspectRatio="none">' +
+            '<rect width="180" height="72" fill="#2f3640"/>' +
+            '<circle cx="144" cy="36" r="45" fill="#3b434f"/>' +
+            '<circle cx="144" cy="36" r="70" fill="#464f5d"/>' +
+            '<circle cx="144" cy="36" r="95" fill="#525c6b"/>' +
+            '<path d="M 40 15 Q 40 22 47 22 Q 40 22 40 29 Q 40 22 33 22 Q 40 22 40 15" fill="#ffffff" opacity="0.9"/>' +
+            '<path d="M 85 40 Q 85 44 89 44 Q 85 44 85 48 Q 85 44 81 44 Q 85 44 85 40" fill="#ffffff" opacity="0.7"/>' +
+            '<circle cx="20" cy="45" r="1.5" fill="#ffffff" opacity="0.8"/>' +
+            '<circle cx="65" cy="25" r="1" fill="#ffffff" opacity="0.6"/>' +
+            '<circle cx="100" cy="18" r="2" fill="#ffffff" opacity="0.9"/>' +
+            '<circle cx="110" cy="55" r="1.5" fill="#ffffff" opacity="0.5"/>' +
+          '</svg>' +
+          '<div class="toggle-knob">' +
+            '<div class="crater crater-1"></div>' +
+            '<div class="crater crater-2"></div>' +
+            '<div class="crater crater-3"></div>' +
+          '</div>' +
+        '</label>' +
+        '<button type="button" class="menu-theme-btn" data-theme-choice="system" aria-pressed="false">Use system setting</button>';
+
       const closeBtn = menuPanel.querySelector('.close-menu');
       menuPanel.insertBefore(picker, closeBtn);
+
+      const themeSwitch = picker.querySelector('#menu-theme-switch');
+      if (themeSwitch) {
+        themeSwitch.addEventListener('change', function () {
+          applyTheme(this.checked ? 'dark' : 'light');
+        });
+      }
 
       picker.querySelectorAll('.menu-theme-btn').forEach(function (btn) {
         btn.addEventListener('click', function () { applyTheme(btn.dataset.themeChoice); });

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -54,149 +54,55 @@
           <div class="med-guide__header">
             <div class="med-guide__header-text">
               <h2>The tared scale method</h2>
-              <p>Watch the demo, then follow the four numbered steps below. The whole process takes about 30 seconds.</p>
+              <p>Watch the animation below to see how to use the tared scale method. The whole process takes about 30 seconds.</p>
             </div>
           </div>
 
-          <!-- Animated SVG demo -->
+          <!-- Animated demo -->
           <div class="tare-demo">
-            <svg
-              class="tare-svg"
-              viewBox="0 0 400 290"
-              xmlns="http://www.w3.org/2000/svg"
-              role="img"
-              aria-label="Animation: a parent steps on a bathroom scale alone, steps off, presses the TARE button so the scale reads zero, then steps on again holding their baby. The scale now displays only the baby's weight."
-            >
-              <!-- Floor -->
-              <line x1="20" y1="248" x2="380" y2="248" stroke="#cbd5e1" stroke-width="2" stroke-linecap="round" />
-
-              <!-- Scale shadow -->
-              <ellipse cx="200" cy="252" rx="92" ry="4" fill="rgba(15,44,42,0.12)" />
-
-              <!-- Scale base -->
-              <rect x="115" y="220" width="170" height="26" rx="5" fill="#1f2937" />
-              <rect x="120" y="226" width="160" height="14" rx="3" fill="#374151" />
-
-              <!-- Scale display screen -->
-              <rect x="155" y="194" width="90" height="26" rx="5" fill="#0f172a" stroke="#374151" stroke-width="1" />
-
-              <!-- Display values (overlapping, animated opacity) -->
-              <text x="200" y="213" class="display-num display-num--1" text-anchor="middle"
-                    font-family="'Courier New', monospace" font-size="15" fill="#22c55e" font-weight="900">150.4</text>
-              <text x="200" y="213" class="display-num display-num--2" text-anchor="middle"
-                    font-family="'Courier New', monospace" font-size="15" fill="#22c55e" font-weight="900">0.0</text>
-              <text x="200" y="213" class="display-num display-num--3" text-anchor="middle"
-                    font-family="'Courier New', monospace" font-size="15" fill="#fbbf24" font-weight="900">17.6</text>
-
-              <!-- "lb" label always visible -->
-              <text x="237" y="213" font-family="'Courier New', monospace" font-size="10" fill="#94a3b8" font-weight="700">lb</text>
-
-              <!-- TARE button (always visible) -->
-              <circle cx="285" cy="232" r="6" fill="#475569" stroke="#1f2937" stroke-width="1" />
-              <text x="285" y="245" text-anchor="middle" font-family="Nunito, sans-serif" font-size="6" fill="#0f2c2a" font-weight="700">TARE</text>
-
-              <!-- TARE button glow (animated highlight) -->
-              <g class="tare-button-glow">
-                <circle cx="285" cy="232" r="14" fill="none" stroke="#fbbf24" stroke-width="2.5" opacity="0.85" />
-                <circle cx="285" cy="232" r="20" fill="none" stroke="#fbbf24" stroke-width="1.5" opacity="0.5" />
-              </g>
-
-              <!-- Person silhouette (animated) -->
-              <g class="person">
-                <!-- Head -->
-                <circle cx="200" cy="115" r="22" fill="#0d8f8a" />
-                <!-- Body -->
-                <rect x="178" y="138" width="44" height="78" rx="10" fill="#0d8f8a" />
-                <!-- Arms -->
-                <rect x="166" y="148" width="14" height="50" rx="7" fill="#0d8f8a" />
-                <rect x="220" y="148" width="14" height="50" rx="7" fill="#0d8f8a" />
-                <!-- Legs (peek below the body) -->
-                <rect x="184" y="210" width="13" height="14" rx="3" fill="#0a706c" />
-                <rect x="203" y="210" width="13" height="14" rx="3" fill="#0a706c" />
-              </g>
-
-              <!-- Baby bundle (animated) -->
-              <g class="baby">
-                <ellipse cx="200" cy="158" rx="20" ry="24" fill="#fbbf24" />
-                <circle cx="200" cy="142" r="9" fill="#fde68a" />
-                <circle cx="197" cy="141" r="1.2" fill="#0f2c2a" />
-                <circle cx="203" cy="141" r="1.2" fill="#0f2c2a" />
-                <path d="M197 145 Q200 147 203 145" stroke="#0f2c2a" stroke-width="0.8" fill="none" stroke-linecap="round" />
-              </g>
-
-              <!-- Captions -->
-              <text x="200" y="278" text-anchor="middle" font-family="Nunito, sans-serif" font-size="12" font-weight="800" fill="#0f2c2a" class="caption caption--1">Step 1 — Step on the scale alone</text>
-              <text x="200" y="278" text-anchor="middle" font-family="Nunito, sans-serif" font-size="12" font-weight="800" fill="#0f2c2a" class="caption caption--2" opacity="0">Step 2 — Step off and wait</text>
-              <text x="200" y="278" text-anchor="middle" font-family="Nunito, sans-serif" font-size="12" font-weight="800" fill="#6b4000" class="caption caption--3" opacity="0">Step 3 — Press the TARE button</text>
-              <text x="200" y="278" text-anchor="middle" font-family="Nunito, sans-serif" font-size="12" font-weight="800" fill="#0d8f8a" class="caption caption--4" opacity="0">Step 4 — Step on holding your baby!</text>
-            </svg>
-
-            <!-- Step indicator dots -->
-            <div class="tare-dots" aria-hidden="true">
-              <span class="tare-dot tare-dot--1"></span>
-              <span class="tare-dot tare-dot--2"></span>
-              <span class="tare-dot tare-dot--3"></span>
-              <span class="tare-dot tare-dot--4"></span>
-            </div>
-          </div>
-
-          <!-- Step-by-step cards (static reference) -->
-          <div class="step-grid">
-            <div class="step-card">
-              <div class="step-card__num">1</div>
-              <div class="step-card__body">
-                <h3 class="step-card__title">Step on alone</h3>
-                <p class="step-card__text">Place a digital bathroom scale on a hard, flat surface. Step on without your baby and wait for the reading to settle.</p>
-              </div>
-            </div>
-            <div class="step-card">
-              <div class="step-card__num">2</div>
-              <div class="step-card__body">
-                <h3 class="step-card__title">Step off the scale</h3>
-                <p class="step-card__text">Step away. Most digital scales will keep displaying your weight for a few seconds.</p>
-              </div>
-            </div>
-            <div class="step-card">
-              <div class="step-card__num">3</div>
-              <div class="step-card__body">
-                <h3 class="step-card__title">Press TARE / ZERO</h3>
-                <p class="step-card__text">Press the <strong>TARE</strong> or <strong>ZERO</strong> button on the scale until the display reads <code>0.0</code>. This tells the scale to ignore your weight on the next reading.</p>
-              </div>
-            </div>
-            <div class="step-card">
-              <div class="step-card__num">4</div>
-              <div class="step-card__body">
-                <h3 class="step-card__title">Step back on with baby</h3>
-                <p class="step-card__text">Hold your baby securely against your chest and step back on. The number now shown is your <strong>baby's weight</strong> alone.</p>
-              </div>
-            </div>
+            <img
+              src="images/tared-weighing-ani.svg"
+              class="tare-anim-img"
+              alt="Animation showing the tared scale method: step on the scale alone, press TARE so the display reads zero, then step back on holding your baby — the scale now shows only your baby's weight."
+            />
           </div>
 
           <!-- Subtraction method (alternative for non-tare scales) -->
-          <details class="tare-alt">
-            <summary>Don't see a TARE / ZERO button on your scale?</summary>
-            <p>Use the <strong>subtraction method</strong>. Weigh yourself, then weigh again holding your baby — the difference is your baby's weight.</p>
-            <ol>
-              <li>Step on the scale alone, write down your weight.</li>
-              <li>Step on again holding your baby, write down that weight.</li>
-              <li>Subtract — that's your baby's weight in pounds.</li>
-            </ol>
-
-            <!-- Inline subtraction calculator -->
-            <div class="tare-calc" role="group" aria-label="Subtraction weight calculator">
-              <label>
-                <span>Your weight alone (lb)</span>
-                <input type="number" id="weight-alone" inputmode="decimal" step="0.1" min="0" placeholder="e.g. 150.4" autocomplete="off" />
-              </label>
-              <label>
-                <span>Weight holding baby (lb)</span>
-                <input type="number" id="weight-with-baby" inputmode="decimal" step="0.1" min="0" placeholder="e.g. 168.0" autocomplete="off" />
-              </label>
-              <div class="tare-calc__result" id="tare-result" aria-live="polite">
-                Enter both weights to see your baby's weight.
+          <div class="tare-alt-wrapper">
+            <button type="button" class="no-tare-btn" id="noTareBtn" aria-expanded="false" aria-controls="subtractionCalc">
+              No TARE / ZERO feature?
+            </button>
+            <div id="subtractionCalc" class="subtraction-calc-card" hidden>
+              <div class="subtraction-calc" role="group" aria-label="Subtraction weight calculator">
+                <div class="subtraction-calc__header">
+                  <span class="subtraction-calc__header-icon" aria-hidden="true">−</span>
+                  <span class="subtraction-calc__header-title">Subtraction Method</span>
+                </div>
+                <div class="subtraction-calc__screen" id="tare-result" aria-live="polite">
+                  <span class="subtraction-calc__screen-label">Baby's weight</span>
+                  <span class="subtraction-calc__screen-val subtraction-calc__screen-val--placeholder" id="tare-screen-val">— —</span>
+                </div>
+                <div class="subtraction-calc__keys">
+                  <label class="subtraction-calc__field">
+                    <span class="subtraction-calc__field-label">Your weight alone</span>
+                    <div class="subtraction-calc__field-row">
+                      <input type="number" id="weight-alone" inputmode="decimal" step="0.1" min="0" placeholder="0.0" autocomplete="off" />
+                      <span class="subtraction-calc__unit">lb</span>
+                    </div>
+                  </label>
+                  <div class="subtraction-calc__op" aria-hidden="true">−</div>
+                  <label class="subtraction-calc__field">
+                    <span class="subtraction-calc__field-label">Weight holding baby</span>
+                    <div class="subtraction-calc__field-row">
+                      <input type="number" id="weight-with-baby" inputmode="decimal" step="0.1" min="0" placeholder="0.0" autocomplete="off" />
+                      <span class="subtraction-calc__unit">lb</span>
+                    </div>
+                  </label>
+                  <div class="subtraction-calc__error" id="tare-error" aria-live="polite" hidden></div>
+                </div>
               </div>
             </div>
-          </details>
+          </div>
 
           <!-- Tips card -->
           <div class="tip-card">
@@ -286,28 +192,54 @@
 
   <script src="global.js" defer></script>
   <script>
+    // No-tare button expand/collapse
+    (function () {
+      var btn = document.getElementById('noTareBtn');
+      var card = document.getElementById('subtractionCalc');
+      if (!btn || !card) return;
+      btn.addEventListener('click', function () {
+        var expanded = btn.getAttribute('aria-expanded') === 'true';
+        btn.setAttribute('aria-expanded', String(!expanded));
+        card.hidden = expanded;
+        if (!expanded) {
+          var firstInput = card.querySelector('input');
+          if (firstInput) firstInput.focus();
+        }
+      });
+    })();
+
     // Subtraction calculator (live update)
     (function () {
       var alone = document.getElementById('weight-alone');
       var withBaby = document.getElementById('weight-with-baby');
-      var result = document.getElementById('tare-result');
-      if (!alone || !withBaby || !result) return;
+      var screenVal = document.getElementById('tare-screen-val');
+      var errorEl = document.getElementById('tare-error');
+      if (!alone || !withBaby || !screenVal) return;
 
       function update() {
         var a = parseFloat(alone.value);
         var b = parseFloat(withBaby.value);
-        if (isFinite(a) && isFinite(b)) {
+        var hasA = alone.value !== '' && isFinite(a);
+        var hasB = withBaby.value !== '' && isFinite(b);
+
+        if (hasA && hasB) {
           if (b > a) {
             var diff = (b - a).toFixed(1);
-            result.innerHTML = "Baby's weight: <strong>" + diff + " lb</strong>";
-            result.classList.add('has-result');
+            screenVal.textContent = diff + ' lb';
+            screenVal.classList.remove('subtraction-calc__screen-val--placeholder', 'subtraction-calc__screen-val--error');
+            screenVal.classList.add('subtraction-calc__screen-val--result');
+            if (errorEl) errorEl.hidden = true;
           } else {
-            result.textContent = "The 'with baby' weight should be greater than your weight alone.";
-            result.classList.remove('has-result');
+            screenVal.textContent = 'ERR';
+            screenVal.classList.remove('subtraction-calc__screen-val--placeholder', 'subtraction-calc__screen-val--result');
+            screenVal.classList.add('subtraction-calc__screen-val--error');
+            if (errorEl) { errorEl.textContent = '"With baby" weight must be greater than your weight alone.'; errorEl.hidden = false; }
           }
         } else {
-          result.textContent = "Enter both weights to see your baby's weight.";
-          result.classList.remove('has-result');
+          screenVal.textContent = '— —';
+          screenVal.classList.remove('subtraction-calc__screen-val--result', 'subtraction-calc__screen-val--error');
+          screenVal.classList.add('subtraction-calc__screen-val--placeholder');
+          if (errorEl) errorEl.hidden = true;
         }
       }
       alone.addEventListener('input', update);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Animation**: Replace the inline SVG with `public/images/tared-weighing-ani.svg` displayed via an `<img>` tag; removes step indicator dots (which were tied to inline SVG keyframes)
- **Step cards removed**: The four written step cards below the animation have been removed
- **Collapsible subtraction calculator**: The `<details>` element is replaced with a "No TARE / ZERO feature?" button that expands a dark, calculator-style card — dark display screen shows the live baby weight result, two monospace input rows with a `−` operator between them, and an inline error message if values are invalid
- **Day/Night/System toggle moved to menu only**: The floating emoji toggle button is removed; the hamburger menu now contains the animated sun/moon SVG slider (sky-to-stars transition with sliding knob, craters on moon) plus a "Use system setting" pill button below it

## Test plan

- [ ] Open `weighing-guide.html` — verify `tared-weighing-ani.svg` loads and plays
- [ ] Confirm no step cards are shown below the animation
- [ ] Click "No TARE / ZERO feature?" — card expands with dark calculator UI
- [ ] Enter values in both inputs — screen updates live with result; entering invalid values shows ERR + error message
- [ ] Click button again — card collapses
- [ ] Confirm no floating moon/sun toggle button appears on any page
- [ ] Open hamburger menu — animated day/night toggle is present; toggling switches theme; "Use system setting" button works
- [ ] Test light/dark/system modes persist across page reload

https://claude.ai/code/session_01GSsXnjh5ddsEhfHtUhEfRC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSsXnjh5ddsEhfHtUhEfRC)_