### PR TITLE
Rebrand header, favicon, and menu layout

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -6,7 +6,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – About</title>
   <meta property="og:type" content="website" />
@@ -23,7 +24,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/contact.html
+++ b/public/contact.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – Contact</title>
   <meta property="og:type" content="website" />
@@ -24,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
 
   <title>CloseDose Family Dashboard</title>
@@ -17,7 +18,7 @@
   <div class="wrap">
     
     <header>
-      <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>

--- a/public/donations.html
+++ b/public/donations.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – Support our work</title>
   <meta property="og:type" content="website" />
@@ -24,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – How to measure liquid medicine</title>
   <meta property="og:type" content="website" />
@@ -24,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/global.css
+++ b/public/global.css
@@ -162,52 +162,46 @@ select[hidden] {
 
 header {
   position: relative;
-  top: 0;
   z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(12px, 3vw, 32px);
-  padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+  width: 100%;
+  padding: clamp(14px, 3vw, 26px) 0 clamp(6px, 2vw, 14px);
   margin-bottom: 0;
 }
 
 .header-wordmark {
   display: block;
-  width: min(390px, 60vw);
-  max-width: 100%;
+  width: 100%;
+  max-width: 100vw;
   height: auto;
-  margin: 0 auto;
 }
 
 .menu-btn {
   appearance: none;
   border: var(--card-border);
-  border-radius: 50%;
+  border-radius: 999px;
   background: var(--white);
   color: var(--ink-900);
   font-weight: 900;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  padding: 12px;
-  font-size: 0;
+  padding: 12px 20px;
+  font-size: 0.95rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
   cursor: pointer;
   box-shadow: var(--shadow-btn);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease, width 0.18s ease, padding 0.18s ease, border-radius 0.18s ease;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
   position: fixed;
   top: clamp(16px, 3vw, 32px);
-  right: clamp(18px, 5vw, 48px);
+  left: clamp(18px, 5vw, 48px);
   z-index: 1200;
-  width: 56px;
   height: 56px;
 }
 
-.menu-btn .label { display: none; }
-.menu-btn .hamburger { width: 24px; height: 16px; position: relative; }
+.menu-btn .label { display: inline; }
+.menu-btn .hamburger { width: 24px; height: 16px; position: relative; flex-shrink: 0; }
 .menu-btn .hamburger span { position: absolute; left: 0; right: 0; height: 3px; border-radius: 999px; background: var(--ink-900); transition: background 0.12s ease; }
 .menu-btn .hamburger span:nth-child(1) { top: 0; }
 .menu-btn .hamburger span:nth-child(2) { top: 6px; }
@@ -215,16 +209,22 @@ header {
 
 .menu-btn:hover, .menu-btn:focus-visible { background: #f0faf6; box-shadow: 0 5px 0 rgba(15, 44, 42, 0.35); outline: none; }
 .menu-btn:active { transform: translateY(2px); box-shadow: inset 0 4px 8px rgba(15, 44, 42, 0.25); }
-.menu-btn.is-expanded { width: auto; height: 56px; padding: 12px 20px; border-radius: 999px; font-size: 0.95rem; }
-.menu-btn.is-expanded .label { display: inline; }
 
-@media (max-width: 960px) {
-  header { padding-inline: clamp(16px, 5vw, 32px); }
-  .menu-btn { top: auto; bottom: clamp(20px, 6vw, 40px); right: auto; left: clamp(20px, 6vw, 40px); box-shadow: 0 8px 0 rgba(15, 44, 42, 0.35); }
-}
-
+/* Narrow screens: icon-only at bottom-left */
 @media (max-width: 640px) {
-  header { background: transparent !important; padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px); }
+  header { background: transparent !important; padding: clamp(10px, 3vw, 18px) 0 clamp(4px, 2vw, 12px); }
+  .menu-btn {
+    top: auto;
+    left: clamp(20px, 6vw, 40px);
+    bottom: clamp(20px, 6vw, 40px);
+    width: 56px;
+    height: 56px;
+    padding: 12px;
+    border-radius: 50%;
+    font-size: 0;
+    box-shadow: 0 8px 0 rgba(15, 44, 42, 0.35);
+  }
+  .menu-btn .label { display: none; }
 }
 
 main {
@@ -553,7 +553,7 @@ main {
 .disclaimer-close:hover { background: rgba(15, 44, 42, 0.06); }
 
 /* --- Header link wrapper --- */
-.header-link { display: inline-block; line-height: 0; }
+.header-link { display: block; width: 100%; line-height: 0; }
 .header-link:focus-visible { outline: 3px solid var(--teal-400); outline-offset: 4px; border-radius: 8px; }
 
 /* Cappy Waitlist Pill - SMALLER & BOTTOM RIGHT */
@@ -2576,4 +2576,26 @@ html[data-theme="light"] .menu-theme-btn.is-active {
   background: var(--ink-900);
   border-color: var(--ink-900);
   color: #fff;
+}
+
+@layer components {
+  .svg-pomegranate-logo {
+    position: relative;
+  }
+
+  .svg-pomegranate-logo svg {
+    overflow: visible;
+  }
+
+  .svg-pomegranate-logo > div {
+    transform-origin: 0 90%;
+  }
+
+  .svg-pomegranate-logo > div:last-child {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,10 +15,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="images/favicon-192.png">
-  <link rel="apple-touch-icon" href="images/logo-teal.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="manifest" href="manifest.json">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
   <script>
@@ -36,21 +34,13 @@
   <div class="wrap">
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
       </button>
     </header>
-
-    <button class="cappy-floating-btn" type="button" data-cappy-trigger aria-controls="cappyWaitlistModal" aria-expanded="false" aria-label="Join the Cappy wait list">
-      <img src="images/cappy_circle.png" alt="" />
-      <div class="cappy-waitlist-content">
-        <span class="cappy-waitlist-brand">Cappy!</span>
-        <span class="cappy-waitlist-tagline">Join the waitlist today</span>
-      </div>
-    </button>
 
     <main>
       <section class="hero" aria-labelledby="hero-heading">

--- a/public/login.html
+++ b/public/login.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
 
   <title>CloseDose Login</title>
@@ -17,7 +18,7 @@
   <div class="wrap">
     
     <header>
-      <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+      <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,17 +10,10 @@
   "background_color": "#ffffff",
   "icons": [
     {
-      "src": "images/logo-teal.png",
+      "src": "images/LOGO-WC.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
-    },
-    {
-      "src": "images/logo-dark.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any",
-      "media": "(prefers-color-scheme: dark)"
     }
   ]
 }

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -6,7 +6,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – Medication Guides</title>
   <meta name="description" content="Browse acetaminophen and ibuprofen product guides with concentration-sorted photo galleries, formulation options, and pediatric safety tips." />
@@ -24,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -7,7 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
-  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" href="images/LOGO-WC.png">
+  <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – How to weigh your baby at home</title>
   <meta property="og:type" content="website" />
@@ -24,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/CD_Word.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Favicon/app icon**: All pages and `manifest.json` now reference `images/LOGO-WC.png` (replaces favicon-16/32/192 and logo-teal/dark)
- **Header wordmark**: `CD_Word.png` replaced with `images/Logomark-WC.png` across all 9 pages; header is now full-width with the logomark spanning 100vw and scaling responsively
- **Menu button**: Repositioned to top-left on desktop, displaying MENU label + hamburger when screen ≥ 640px; collapses to icon-only at bottom-left on screens < 640px
- **Cappy floating button**: Removed from `index.html`; modal HTML, CSS, and JS are all preserved in the repo for easy restoration
- **`.svg-pomegranate-logo`**: Added `@layer components` block to `global.css` (also fixed the space typo in `:last-child` selector)

## ⚠️ Action required before deploying

Two image files need to be added to `public/images/`:
- `LOGO-WC.png` — used as favicon, apple-touch-icon, and PWA manifest icon
- `Logomark-WC.png` — used as the full-width header wordmark

## Test plan

- [ ] Drop `LOGO-WC.png` and `Logomark-WC.png` into `public/images/`
- [ ] Verify favicon appears in browser tab on all pages
- [ ] Verify logomark spans full page width and scales on window resize
- [ ] Verify MENU button is top-left on desktop with label visible
- [ ] Verify MENU button collapses to icon-only at bottom-left on mobile (< 640px)
- [ ] Verify Cappy button is gone from index page; other pages unaffected
- [ ] Verify Cappy waitlist modal still opens if triggered programmatically

https://claude.ai/code/session_01RVUHQ6VCDdfkZFtp4VyQ4a
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVUHQ6VCDdfkZFtp4VyQ4a)_