### PR TITLE
Fix header wordmark size — cap max-width at 320px

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -171,7 +171,7 @@ header {
 .header-wordmark {
   display: block;
   width: 100%;
-  max-width: 100vw;
+  max-width: 320px;
   height: auto;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `.header-wordmark` was set to `width: 100%` / `max-width: 100vw`, allowing the logo to expand to the full viewport width on large screens
- Changed `max-width` from `100vw` to `320px` to cap the logo at a sensible size across all pages

## Test plan

- [ ] Verify the wordmark renders at a reasonable size on desktop (wide viewport)
- [ ] Verify the wordmark still scales down correctly on mobile (narrow viewport)
- [ ] Check all pages that use `.header-wordmark`: index, about, contact, donations, weighing-guide, dosing-guide, medication-guides, dashboard, login

https://claude.ai/code/session_01L522nJAptt7iTHJcJAZxVq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L522nJAptt7iTHJcJAZxVq)_