### PR TITLE
Promote wordmark hero above calculator + branded sidebar/footer

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -277,6 +277,109 @@ main {
   color: var(--hero-sub-color);
 }
 
+/* --- Brand hero (home page wordmark) --- */
+.site-header--home {
+  min-height: 0;
+  padding: 0;
+}
+
+.brand-hero {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 4vw, 36px) 0 clamp(14px, 2.5vw, 24px);
+  margin: 0 auto;
+  animation: slam-in 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
+}
+
+.brand-hero__link {
+  display: flex;
+  width: 75%;
+  max-width: 620px;
+  justify-content: center;
+  text-decoration: none;
+  border-radius: 12px;
+  transition: transform 0.25s ease;
+}
+
+.brand-hero__link:hover,
+.brand-hero__link:focus-visible {
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.brand-hero__link:focus-visible {
+  outline: 3px solid var(--teal-400);
+  outline-offset: 6px;
+}
+
+.brand-hero__wordmark {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(0 6px 22px rgba(13, 52, 82, 0.18));
+}
+
+@media (prefers-color-scheme: dark) {
+  .brand-hero__wordmark {
+    filter: drop-shadow(0 6px 24px rgba(0, 0, 0, 0.55));
+  }
+}
+
+html[data-theme="dark"] .brand-hero__wordmark {
+  filter: drop-shadow(0 6px 24px rgba(0, 0, 0, 0.55));
+}
+
+@media (max-width: 640px) {
+  .brand-hero {
+    padding: clamp(8px, 4vw, 18px) 0 clamp(8px, 3vw, 16px);
+  }
+  .brand-hero__link {
+    width: 82%;
+  }
+}
+
+@media (max-width: 380px) {
+  .brand-hero__link {
+    width: 88%;
+  }
+}
+
+/* --- Brand blurb (sidebar / under-calc on mobile) --- */
+.brand-blurb {
+  display: grid;
+  gap: 10px;
+  text-align: left;
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(232, 245, 240, 0.92));
+}
+
+.brand-blurb__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--teal-500);
+}
+
+.brand-blurb__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 0.6vw + 1.05rem, 1.55rem);
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--ink-900);
+}
+
+.brand-blurb__body {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: var(--ink-900);
+}
+
 /* --- Layout: single-column scrolling --- */
 .layout {
   width: min(720px, 100%);
@@ -304,6 +407,46 @@ main {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+/* On desktop, expose a sidebar layout so the blurb + helper cards
+   live next to the calculator column. On mobile/tablet the same
+   sidebar collapses below the calculator. */
+
+@media (min-width: 1024px) {
+  .layout--grid {
+    width: min(1140px, 100%);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+    align-items: start;
+    gap: clamp(20px, 2.4vw, 32px);
+  }
+  .layout--secondary {
+    width: min(1140px, 100%);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+    align-items: start;
+    gap: clamp(20px, 2.4vw, 32px);
+  }
+  .layout--secondary > .card {
+    grid-column: 1;
+    max-width: 720px;
+  }
+  .calculator-column {
+    min-width: 0;
+    max-width: 720px;
+    width: 100%;
+    justify-self: start;
+  }
+  .info-column {
+    position: sticky;
+    top: clamp(20px, 3vw, 32px);
+    align-self: start;
+  }
+  .brand-hero__link {
+    width: 75%;
+    max-width: 560px;
+  }
 }
 
 .calculator-trust {
@@ -642,6 +785,25 @@ main {
   padding: 48px 24px;
   text-align: center;
   border-top: 1px solid var(--footer-border);
+}
+.cd-footer-logo-link {
+  display: inline-block;
+  margin: 0 auto 20px;
+  line-height: 0;
+  border-radius: 50%;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+.cd-footer-logo-link:hover,
+.cd-footer-logo-link:focus-visible {
+  transform: translateY(-2px);
+  filter: drop-shadow(0 8px 18px rgba(77, 208, 225, 0.35));
+  outline: none;
+}
+.cd-footer-logo {
+  display: block;
+  width: clamp(96px, 12vw, 132px);
+  height: auto;
+  margin: 0 auto;
 }
 .cd-copy { font-weight: 700; margin-bottom: 24px; }
 .cd-legal { display: flex; justify-content: center; flex-wrap: wrap; gap: 16px; margin-bottom: 24px; }

--- a/public/index.html
+++ b/public/index.html
@@ -31,11 +31,8 @@
 <body>
   <a class="skip-link" href="#calculator-card">Skip to calculator</a>
 
-  <div class="wrap">
-    <header>
-      <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
-      </a>
+  <div class="wrap wrap--home">
+    <header class="site-header site-header--home">
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
@@ -43,14 +40,22 @@
     </header>
 
     <main>
-      <section class="hero" aria-labelledby="hero-heading">
-        <p class="hero-eyebrow">Built by pediatric physicians · Free for families</p>
-        <h1 id="hero-heading" class="hero-title">Confident pediatric dosing in seconds.</h1>
-        <p class="hero-sub">Enter your child's age and weight to get accurate acetaminophen and ibuprofen dosing — no account, no math, no guesswork.</p>
-      </section>
-
       <div class="layout layout--grid">
         <div class="calculator-column">
+          <section class="brand-hero" aria-label="CloseDose">
+            <a href="index.html" class="brand-hero__link" aria-label="CloseDose home">
+              <img
+                src="images/CloseDose_ExtendedLogo.svg"
+                alt="CloseDose — pediatric dosing calculator"
+                class="brand-hero__wordmark"
+                width="1830"
+                height="750"
+                fetchpriority="high"
+              />
+            </a>
+            <h1 id="hero-heading" class="visually-hidden">CloseDose — confident pediatric dosing in seconds</h1>
+          </section>
+
           <div class="calculator-widget-host" id="calculator-card" data-calculator-root></div>
 
           <p class="calculator-trust">
@@ -60,6 +65,12 @@
         </div>
 
         <aside class="info-column" aria-label="How to use and safety reminders">
+          <section class="card brand-blurb" aria-labelledby="brand-blurb-heading">
+            <p class="brand-blurb__eyebrow">Built by pediatric physicians · Free for families</p>
+            <h2 id="brand-blurb-heading" class="brand-blurb__title">Confident pediatric dosing in seconds.</h2>
+            <p class="brand-blurb__body">Enter your child's age and weight to get accurate acetaminophen and ibuprofen dosing — no account, no math, no guesswork.</p>
+          </section>
+
           <a class="cross-link-card" href="weighing-guide.html" aria-label="Open the weighing guide for infants and young children">
             <span class="cross-link-card__emoji" aria-hidden="true">⚖️</span>
             <span class="cross-link-card__body">
@@ -152,6 +163,9 @@
   </div>
 
   <footer class="cd-footer" role="contentinfo">
+    <a href="index.html" class="cd-footer-logo-link" aria-label="CloseDose home">
+      <img src="images/LOGO-WC.png" alt="CloseDose" class="cd-footer-logo" width="800" height="800" loading="lazy" />
+    </a>
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>


### PR DESCRIPTION
## Summary

- Make the CloseDose wordmark (`CloseDose_ExtendedLogo.svg`) the central, page-opening brand element by mounting it above the calculator card. It centers on the card and spans 75% of the card width on desktop, expanding to 82–88% on mobile for legibility.
- Move the "Built by pediatric physicians · Confident pediatric dosing in seconds…" blurb out of the top-of-page hero into a dedicated `brand-blurb` card. On desktop (≥1024px) it lives in a sticky sidebar next to the calculator; on mobile/tablet it collapses to sit directly beneath the calculator.
- Add the `LOGO-WC.png` mark to the site footer for consistent branding across the page.
- Remove the duplicated small header wordmark on the home page so the hero is unmistakably the main brand moment.

## Layout

- **Desktop (≥1024px):** two-column grid — calculator column (max 720px) on the left with the hero wordmark + calculator, and a sticky sidebar (`brand-blurb` + cross-links + safety/use cards) on the right. Donate/disclaimer cards align under the calculator column.
- **Mobile/tablet (<1024px):** single column — hero wordmark, calculator, trust line, then the brand blurb, cross-links, safety cards, donate, disclaimer.

## Test plan

- [ ] Open `/` on desktop (≥1024px); confirm the wordmark sits centered above the calculator at ~75% of card width and the sidebar (blurb + links + safety cards) is visible to the right.
- [ ] Resize to tablet (~900px) and mobile (~375px); confirm the wordmark scales smoothly, stays legible, and the blurb reflows directly under the calculator.
- [ ] Verify the footer shows the `LOGO-WC.png` mark, links to `/`, and is keyboard-focusable.
- [ ] Verify menu button still opens the site menu and the skip-link still jumps to the calculator.
- [ ] Toggle dark mode and confirm wordmark drop-shadow remains tasteful.

https://claude.ai/code/session_01B7N95AERYHd9iC4RjY6JKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7N95AERYHd9iC4RjY6JKb)_