### PR TITLE
Replace hero logo with Logomark-WC.png and dedupe homepage logomark

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,11 +45,11 @@
           <section class="brand-hero" aria-label="CloseDose">
             <a href="index.html" class="brand-hero__link" aria-label="CloseDose home">
               <img
-                src="images/CloseDose_ExtendedLogo.svg"
+                src="images/Logomark-WC.png"
                 alt="CloseDose — pediatric dosing calculator"
                 class="brand-hero__wordmark"
-                width="1830"
-                height="750"
+                width="3906"
+                height="3906"
                 fetchpriority="high"
               />
             </a>
@@ -196,7 +196,7 @@
     window.addEventListener('DOMContentLoaded', function () {
       var host = document.querySelector('[data-calculator-root]');
       if (host && window.CloseDoseCalculator) {
-        window.CloseDoseCalculator.mount(host, { id: 'main-calculator' });
+        window.CloseDoseCalculator.mount(host, { id: 'main-calculator', logomarkSrc: '' });
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- Swap the homepage brand hero from `images/CloseDose_ExtendedLogo.svg` to `images/Logomark-WC.png` (with updated intrinsic dimensions)
- Pass `logomarkSrc: ''` when mounting the calculator on `index.html` so the widget no longer renders its built-in `cdcalc-wrapper--has-logomark` mark — only one logomark is shown above the calculator

## Test plan
- [ ] Load `/` and confirm the hero shows the new `Logomark-WC.png`
- [ ] Confirm the calculator card has no second logomark above it (no `cdcalc-wrapper--has-logomark` on index)
- [ ] Verify other embeds of the calculator (outside index) still display their default logomark

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzeM44AFT5MkdKr5GbvDTW)_