### PR TITLE
Tighten spacing around home logomark

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -240,6 +240,10 @@ main {
   overflow-x: hidden;
 }
 
+.wrap--home main {
+  padding-top: clamp(2px, 0.8vw, 8px);
+}
+
 /* --- Hero --- */
 .hero {
   width: min(720px, 100%);
@@ -289,7 +293,7 @@ main {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(18px, 4vw, 36px) 0 clamp(14px, 2.5vw, 24px);
+  padding: clamp(6px, 1.5vw, 16px) 0 clamp(2px, 0.8vw, 8px);
   margin: 0 auto;
   animation: slam-in 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
 }
@@ -334,7 +338,7 @@ html[data-theme="dark"] .brand-hero__wordmark {
 
 @media (max-width: 640px) {
   .brand-hero {
-    padding: clamp(8px, 4vw, 18px) 0 clamp(8px, 3vw, 16px);
+    padding: clamp(2px, 1.5vw, 8px) 0 clamp(2px, 1vw, 6px);
   }
   .brand-hero__link {
     width: 82%;
@@ -406,7 +410,7 @@ html[data-theme="dark"] .brand-hero__wordmark {
 .calculator-column {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 6px;
 }
 
 /* On desktop, expose a sidebar layout so the blurb + helper cards


### PR DESCRIPTION
## Summary
- Reduced `.brand-hero` top/bottom padding (and the mobile override) so the CloseDose logomark sits closer to the page top and the calculator card.
- Reduced the `.calculator-column` flex gap from 12px to 6px to pull the calculator card up under the logomark.
- Added a `.wrap--home main` padding-top override to trim the additional top padding on the home page only, leaving other pages unaffected.

## Test plan
- [ ] Load the home page on desktop and verify reduced gap above and below the logomark.
- [ ] Load the home page on mobile (<=640px) and verify the logomark and calculator are visibly tighter.
- [ ] Visit a non-home page (about, dosing-guide, etc.) and confirm header/main spacing is unchanged.

https://claude.ai/code/session_012T6GJuM2mYpuiGBkptGnic

---
_Generated by [Claude Code](https://claude.ai/code/session_012T6GJuM2mYpuiGBkptGnic)_