### PR TITLE
Use logomark-WC.png as hallmark branding across all pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -24,7 +24,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/contact.html
+++ b/public/contact.html
@@ -25,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -18,7 +18,7 @@
   <div class="wrap">
     
     <header>
-      <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+      <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>

--- a/public/donations.html
+++ b/public/donations.html
@@ -25,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -25,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/index.html
+++ b/public/index.html
@@ -45,11 +45,11 @@
           <section class="brand-hero" aria-label="CloseDose">
             <a href="index.html" class="brand-hero__link" aria-label="CloseDose home">
               <img
-                src="images/Logomark-WC.png"
+                src="images/logomark-WC.png"
                 alt="CloseDose — pediatric dosing calculator"
                 class="brand-hero__wordmark"
-                width="3906"
-                height="3906"
+                width="3679"
+                height="1744"
                 fetchpriority="high"
               />
             </a>

--- a/public/legal/disclaimer.html
+++ b/public/legal/disclaimer.html
@@ -9,7 +9,7 @@
 <body>
   <div class="legal-page">
     <header class="legal-header">
-      <div class="legal-brand">CloseDose</div>
+      <div class="legal-brand"><a href="../index.html" aria-label="CloseDose home"><img src="../images/logomark-WC.png" alt="CloseDose" /></a></div>
       <h1 class="legal-title">Medical &amp; Site Disclaimer</h1>
       <p class="legal-tagline">Important safety information about using CloseDose dosing calculators.</p>
       <p class="legal-meta">Effective Date: <strong>October 02, 2025</strong></p>

--- a/public/legal/dmca.html
+++ b/public/legal/dmca.html
@@ -9,7 +9,7 @@
 <body>
   <div class="legal-page">
     <header class="legal-header">
-      <div class="legal-brand">CloseDose</div>
+      <div class="legal-brand"><a href="../index.html" aria-label="CloseDose home"><img src="../images/logomark-WC.png" alt="CloseDose" /></a></div>
       <h1 class="legal-title">DMCA Policy</h1>
       <p class="legal-tagline">How to report copyright concerns related to CloseDose content.</p>
       <p class="legal-meta">Effective Date: <strong>October 02, 2025</strong></p>

--- a/public/legal/legal.css
+++ b/public/legal/legal.css
@@ -45,11 +45,23 @@ a:hover,a:focus{text-decoration:underline;}
   box-shadow:0 10px 30px rgba(18,57,52,0.18);
 }
 .legal-brand{
-  text-transform:uppercase;
-  letter-spacing:0.22em;
-  font-size:0.78rem;
-  font-weight:700;
-  opacity:0.9;
+  display:inline-block;
+}
+.legal-brand a{
+  display:inline-block;
+  border-radius:12px;
+  outline:none;
+}
+.legal-brand a:focus-visible{
+  outline:3px solid rgba(255,255,255,0.8);
+  outline-offset:6px;
+}
+.legal-brand img{
+  display:block;
+  width:clamp(160px,28vw,240px);
+  height:auto;
+  margin:0 auto;
+  filter:drop-shadow(0 6px 18px rgba(0,0,0,0.18));
 }
 .legal-title{
   margin:12px 0 6px;

--- a/public/legal/linking.html
+++ b/public/legal/linking.html
@@ -9,7 +9,7 @@
 <body>
   <div class="legal-page">
     <header class="legal-header">
-      <div class="legal-brand">CloseDose</div>
+      <div class="legal-brand"><a href="../index.html" aria-label="CloseDose home"><img src="../images/logomark-WC.png" alt="CloseDose" /></a></div>
       <h1 class="legal-title">Acceptable Use &amp; Linking Policy</h1>
       <p class="legal-tagline">Guidelines for referencing CloseDose and interacting with our Services.</p>
       <p class="legal-meta">Effective Date: <strong>October 02, 2025</strong></p>

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -9,7 +9,7 @@
 <body>
   <div class="legal-page">
     <header class="legal-header">
-      <div class="legal-brand">CloseDose</div>
+      <div class="legal-brand"><a href="../index.html" aria-label="CloseDose home"><img src="../images/logomark-WC.png" alt="CloseDose" /></a></div>
       <h1 class="legal-title">Privacy Policy</h1>
       <p class="legal-tagline">How we collect, use, and safeguard information on CloseDose.com.</p>
       <p class="legal-meta">Effective Date: <strong>October 02, 2025</strong></p>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -9,7 +9,7 @@
 <body>
   <div class="legal-page">
     <header class="legal-header">
-      <div class="legal-brand">CloseDose</div>
+      <div class="legal-brand"><a href="../index.html" aria-label="CloseDose home"><img src="../images/logomark-WC.png" alt="CloseDose" /></a></div>
       <h1 class="legal-title">Terms of Use</h1>
       <p class="legal-tagline">Understand the rules that govern your access to CloseDose tools and content.</p>
       <p class="legal-meta">Effective Date: <strong>October 02, 2025</strong></p>

--- a/public/login.html
+++ b/public/login.html
@@ -18,7 +18,7 @@
   <div class="wrap">
     
     <header>
-      <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+      <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -25,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/share/index.html
+++ b/public/share/index.html
@@ -59,6 +59,28 @@
       gap: 16px;
     }
 
+    .share-brand {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 4px;
+    }
+
+    .share-brand a {
+      display: inline-block;
+      border-radius: 12px;
+    }
+
+    .share-brand a:focus-visible {
+      outline: 3px solid var(--color-text);
+      outline-offset: 4px;
+    }
+
+    .share-brand img {
+      display: block;
+      width: clamp(180px, 40%, 260px);
+      height: auto;
+    }
+
     h1, h2, h3, p { margin: 0; }
 
     .details-grid {
@@ -96,6 +118,11 @@
 </head>
 <body>
   <main class="card" aria-live="polite">
+    <div class="share-brand">
+      <a href="../index.html" aria-label="CloseDose home">
+        <img src="../images/logomark-WC.png" alt="CloseDose" />
+      </a>
+    </div>
     <h1 data-i18n="share.title">Shared dosing card</h1>
     <p class="status" id="share-status">Loading…</p>
     <div class="details-grid" id="share-details" hidden>

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -25,7 +25,7 @@
 
     <header>
       <a href="index.html" class="header-link" aria-label="CloseDose home">
-        <img src="images/Logomark-WC.png" alt="CloseDose" class="header-wordmark" />
+        <img src="images/logomark-WC.png" alt="CloseDose" class="header-wordmark" />
       </a>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>

--- a/public/widget/close-dose-calculator.js
+++ b/public/widget/close-dose-calculator.js
@@ -161,8 +161,8 @@
       top: 0;
       left: 50%;
       transform: translateX(-50%);
-      width: 120px;
-      height: 120px;
+      width: 200px;
+      height: auto;
       display: block;
       pointer-events: none;
       user-select: none;
@@ -1659,7 +1659,7 @@
 
     const logomarkSrc = Object.prototype.hasOwnProperty.call(options, 'logomarkSrc')
       ? options.logomarkSrc
-      : '/images/Logomark-WC.png';
+      : '/images/logomark-WC.png';
     host.innerHTML = buildMarkup(strings, ids, logomarkSrc);
     const styleElement = injectStyles(host, options);
 

--- a/public/widget/widget/close-dose-calculator.js
+++ b/public/widget/widget/close-dose-calculator.js
@@ -161,8 +161,8 @@
       top: 0;
       left: 50%;
       transform: translateX(-50%);
-      width: 120px;
-      height: 120px;
+      width: 200px;
+      height: auto;
       display: block;
       pointer-events: none;
       user-select: none;
@@ -1659,7 +1659,7 @@
 
     const logomarkSrc = Object.prototype.hasOwnProperty.call(options, 'logomarkSrc')
       ? options.logomarkSrc
-      : '/images/Logomark-WC.png';
+      : '/images/logomark-WC.png';
     host.innerHTML = buildMarkup(strings, ids, logomarkSrc);
     const styleElement = injectStyles(host, options);
 


### PR DESCRIPTION
## Summary

The re-uploaded `images/logomark-WC.png` (now 3679 × 1744 with the
extra vertical padding trimmed) is wired up as the consistent hallmark
across the site:

- **Case fix:** every HTML reference now points to `images/logomark-WC.png`
  to match the file on disk. Previous references to `Logomark-WC.png`
  (capital L) were left over from the deleted file and would 404 on
  case-sensitive servers.
- **Index hero:** updated the intrinsic `width`/`height` attributes on
  `index.html` from `3906×3906` to `3679×1744` so the browser reserves
  the correct layout space and avoids CLS. Existing `.brand-hero__wordmark`
  uses `width: 100%; height: auto;` so the new aspect ratio renders
  correctly and stays centered.
- **Headers (about, contact, dashboard, donations, dosing-guide, login,
  medication-guides, weighing-guide):** kept the `.header-wordmark`
  rule (`display: block; width: clamp(160px, 40%, 260px); height: auto;`)
  which already centers via the flex `header`. With the tighter image,
  the visible logo content displays at roughly the same size as before.
- **Legal pages (disclaimer, dmca, linking, privacy, terms):** replaced
  the small uppercase "CloseDose" text in the gradient header with the
  logomark, linked back to the home page.
- **Shared dosing card (`/share/`):** added the logomark to the top of
  the card, linked back to home.
- **Embed widget:** updated `.cdcalc-logomark` to `width: 200px; height: auto;`
  so the wider aspect ratio is preserved when the widget renders the
  default logomark fallback.

EnteralID.html intentionally keeps its standalone EnteralID branding.

## Test plan
- [ ] Visit `/` and confirm the hero logomark renders at the new aspect ratio without vertical padding.
- [ ] Spot-check `/about`, `/contact`, `/dashboard`, `/donations`, `/dosing-guide`, `/login`, `/medication-guides`, `/weighing-guide` — each header logomark loads (no broken image) and is centered.
- [ ] Visit `/legal/terms`, `/legal/privacy`, `/legal/disclaimer`, `/legal/dmca`, `/legal/linking` — logomark replaces the text wordmark and links back to home.
- [ ] Visit `/share/?token=...` — logomark renders at the top of the card.
- [ ] Confirm `EnteralID.html` is unchanged and still uses its `E` mark.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HesjpAndHSqpNyyYXswbGs)_