### PR TITLE
Add Cappy Run easter-egg game (Konami code + menu tap-bar launcher)

### DIFF
--- a/public/cappy-run.js
+++ b/public/cappy-run.js
@@ -57,100 +57,114 @@
   window.addEventListener('cappyrun:launch', launchGame);
 
   // ----------------------------- Sprite data -----------------------------
-  // Pixel art encoded as strings. '#' = dark, 'o' = light/fill, '.' = transparent.
-  // Mirrors the chunky black-and-white look of the CloseDose capybara logo.
+  // Pixel art encoded as strings. For Cappy sprites the palette is:
+  //   '.' transparent · '#' outline · 'B' body brown · 'L' light tan
+  //   'D' dark shade · 'E' eye black · 'W' eye highlight · 'M' smile
+  // Obstacles still use '#'/'o' against the foreground colors.
+
+  const CAPPY_PALETTE_LIGHT = {
+    '#': '#2b1409',
+    'B': '#a06438',
+    'L': '#d29862',
+    'D': '#6b3a1c',
+    'E': '#0d0703',
+    'W': '#ffffff',
+    'M': '#3d1707',
+  };
+
+  const CAPPY_PALETTE_DARK = {
+    '#': '#1a0c05',
+    'B': '#a06438',
+    'L': '#d29862',
+    'D': '#6b3a1c',
+    'E': '#000000',
+    'W': '#ffffff',
+    'M': '#2a0f04',
+  };
 
   const CAPPY_RUN_A = [
-    '..............####......',
-    '............##oooo##....',
-    '...........#oooooooo#...',
-    '..........#oooooo#oo#...',
-    '..........#oooooooooo#..',
-    '...##########ooooooooo#.',
-    '..#ooooooooooooooooooo#.',
-    '.#ooooooooooooooooooo#..',
-    '.#oooooooooooooooooo#...',
-    '.#oooooooooooooooooo#...',
-    '..#oooooooooooooooo#....',
-    '..#oo##ooooo##oooooo#...',
-    '..#oo##ooooo##oooooo#...',
-    '..#ooooooooooooooooo#...',
-    '...####...####..####....',
-    '...####...####..####....',
-    '...####...####..####....',
+    '..........................',
+    '.................##.......',
+    '.................####.....',
+    '...............#######....',
+    '..............#BBBBBBB#...',
+    '.............#LBBBBBBBB#..',
+    '............#LLBBEEBBBB#..',
+    '...........#LLBBBEWBBBBM#.',
+    '...#########LBBBBBBBBBBM#.',
+    '..#BBBBBBBBBBBBBBBBBBBBM#.',
+    '.#BBBBBBBBBBBBBBBBBBBBB##.',
+    '.#BBLLBBBBBBBBBBBBBBBB#...',
+    '.#BLLBBBBBBBBBBBBBBBBB#...',
+    '..#BBBBBBBBBBBBBBBBBB#....',
+    '...####...####...####.....',
+    '....##.....##.....##......',
   ];
 
   const CAPPY_RUN_B = [
-    '..............####......',
-    '............##oooo##....',
-    '...........#oooooooo#...',
-    '..........#oooooo#oo#...',
-    '..........#oooooooooo#..',
-    '...##########ooooooooo#.',
-    '..#ooooooooooooooooooo#.',
-    '.#ooooooooooooooooooo#..',
-    '.#oooooooooooooooooo#...',
-    '.#oooooooooooooooooo#...',
-    '..#oooooooooooooooo#....',
-    '..#oo##ooooo##oooooo#...',
-    '..#oo##ooooo##oooooo#...',
-    '..#ooooooooooooooooo#...',
-    '....####.####...####....',
-    '....####.####...####....',
-    '.....##...##.....##.....',
+    '..........................',
+    '.................##.......',
+    '.................####.....',
+    '...............#######....',
+    '..............#BBBBBBB#...',
+    '.............#LBBBBBBBB#..',
+    '............#LLBBEEBBBB#..',
+    '...........#LLBBBEWBBBBM#.',
+    '...#########LBBBBBBBBBBM#.',
+    '..#BBBBBBBBBBBBBBBBBBBBM#.',
+    '.#BBBBBBBBBBBBBBBBBBBBB##.',
+    '.#BBLLBBBBBBBBBBBBBBBB#...',
+    '.#BLLBBBBBBBBBBBBBBBBB#...',
+    '..#BBBBBBBBBBBBBBBBBB#....',
+    '....####...####...####....',
+    '.....##.....##.....##.....',
   ];
 
-  // Mid-jump pose (legs tucked)
+  // Mid-jump pose — legs tucked, all four feet off the ground.
   const CAPPY_JUMP = [
-    '..............####......',
-    '............##oooo##....',
-    '...........#oooooooo#...',
-    '..........#oooooo#oo#...',
-    '..........#oooooooooo#..',
-    '...##########ooooooooo#.',
-    '..#ooooooooooooooooooo#.',
-    '.#ooooooooooooooooooo#..',
-    '.#oooooooooooooooooo#...',
-    '.#oooooooooooooooooo#...',
-    '..#oooooooooooooooo#....',
-    '..#oo##ooooo##oooooo#...',
-    '..#oo##ooooo##oooooo#...',
-    '..#ooooooooooooooooo#...',
-    '...#####....##....####..',
-    '........................',
-    '........................',
+    '..........................',
+    '.................##.......',
+    '.................####.....',
+    '...............#######....',
+    '..............#BBBBBBB#...',
+    '.............#LBBBBBBBB#..',
+    '............#LLBBEEBBBB#..',
+    '...........#LLBBBEWBBBBM#.',
+    '...#########LBBBBBBBBBBM#.',
+    '..#BBBBBBBBBBBBBBBBBBBBM#.',
+    '.#BBBBBBBBBBBBBBBBBBBBB##.',
+    '.#BBLLBBBBBBBBBBBBBBBB#...',
+    '.#BLLBBBBBBBBBBBBBBBBB#...',
+    '..#BBBBBBBBBBBBBBBBBB#....',
+    '....##.....##....##.......',
+    '..........................',
   ];
 
-  // Ducking pose (lower profile, longer body) — 12 rows tall so the feet
-  // sit on the ground line when rendered at GROUND_Y - 24.
+  // Ducking pose — body stretched forward and low (10 rows tall, 30 wide).
   const CAPPY_DUCK_A = [
-    '.....................####...',
-    '...................##oooo#..',
-    '..##############oooooooooo#.',
-    '.#ooooooooooooooooooooo#oo#.',
-    '#oooooooooooooooooooooooooo#',
-    '#oooooooooooooooooooooooooo#',
-    '#oo##oooooo##oooooo##oooooo#',
-    '#oo##oooooo##oooooo##oooooo#',
-    '#oooooooooooooooooooooooooo#',
-    '.####...####...####...####..',
-    '.####...####...####...####..',
-    '.####...####...####...####..',
+    '.........................###..',
+    '........................#####.',
+    '...####################BBBBBB#',
+    '..#BBBBBBBBBBBBBBBBBBBBLBEEBB#',
+    '.#BBBBBBBBBBBBBBBBBBBBBLBEWBBM',
+    '#LLBBBBBBBBBBBBBBBBBBBBBBBBBM#',
+    '#BBBBBBBBBBBBBBBBBBBBBBBBBBB#.',
+    '.#BBBBBBBBBBBBBBBBBBBBBBBBB#..',
+    '..####...####...####...####...',
+    '...##.....##.....##.....##....',
   ];
 
   const CAPPY_DUCK_B = [
-    '.....................####...',
-    '...................##oooo#..',
-    '..##############oooooooooo#.',
-    '.#ooooooooooooooooooooo#oo#.',
-    '#oooooooooooooooooooooooooo#',
-    '#oooooooooooooooooooooooooo#',
-    '#oo##oooooo##oooooo##oooooo#',
-    '#oo##oooooo##oooooo##oooooo#',
-    '#oooooooooooooooooooooooooo#',
-    '..####...####...####...####.',
-    '..####...####...####...####.',
-    '...##.....##.....##.....##..',
+    '.........................###..',
+    '........................#####.',
+    '...####################BBBBBB#',
+    '..#BBBBBBBBBBBBBBBBBBBBLBEEBB#',
+    '.#BBBBBBBBBBBBBBBBBBBBBLBEWBBM',
+    '#LLBBBBBBBBBBBBBBBBBBBBBBBBBM#',
+    '#BBBBBBBBBBBBBBBBBBBBBBBBBBB#.',
+    '.#BBBBBBBBBBBBBBBBBBBBBBBBB#..',
+    '...####...####...####...####..',
+    '....##.....##.....##.....##...',
   ];
 
   // Obstacles: pineapple-style plants (Brazilian/Amazonian flair to fit a capybara habitat)
@@ -341,7 +355,7 @@
   CappyRun.prototype._reset = function () {
     this.cappy = {
       x: 60,
-      y: this.GROUND_Y - 34, // sprite height ~34px at scale 2
+      y: this.GROUND_Y - 32, // 16-row sprite × 2 scale
       vy: 0,
       onGround: true,
       ducking: false,
@@ -421,7 +435,7 @@
 
     const duck = this.keys.duck && this.cappy.onGround;
     this.cappy.ducking = duck;
-    const cappyH = duck ? 24 : 34;
+    const cappyH = duck ? 20 : 32;
     const groundY = this.GROUND_Y - cappyH;
     if (this.cappy.y >= groundY) {
       this.cappy.y = groundY;
@@ -468,10 +482,14 @@
   };
 
   CappyRun.prototype._cappyBox = function () {
+    // Sprites are scale-2; the visible body sits inside a small margin so
+    // the collision box trims the transparent borders.
     if (this.cappy.ducking) {
-      return { x: this.cappy.x + 4, y: this.cappy.y + 4, w: 50, h: 18 };
+      // Duck sprite: 30×10 cells → 60×20 px. Body spans cols 0-29, rows 2-7.
+      return { x: this.cappy.x + 4, y: this.cappy.y + 6, w: 54, h: 12 };
     }
-    return { x: this.cappy.x + 6, y: this.cappy.y + 4, w: 38, h: 28 };
+    // Run sprite: 26×16 cells → 52×32 px. Body spans cols 2-23, rows 4-13.
+    return { x: this.cappy.x + 6, y: this.cappy.y + 10, w: 42, h: 20 };
   };
 
   CappyRun.prototype._spawnObstacle = function () {
@@ -576,7 +594,8 @@
     } else {
       cappySprite = (this.cappy.runFrame === 0) ? CAPPY_RUN_A : CAPPY_RUN_B;
     }
-    drawSprite(ctx, cappySprite, this.cappy.x, this.cappy.y, 2, fg, dark ? '#243029' : '#fdfdfd');
+    drawSprite(ctx, cappySprite, this.cappy.x, this.cappy.y, 2,
+      dark ? CAPPY_PALETTE_DARK : CAPPY_PALETTE_LIGHT);
 
     // HUD
     ctx.fillStyle = fg;
@@ -600,19 +619,25 @@
   };
 
   // ------------------------------ Helpers --------------------------------
-  function drawSprite(ctx, rows, x, y, scale, darkColor, lightColor) {
+  function drawSprite(ctx, rows, x, y, scale, darkOrPalette, lightColor) {
+    const palette = (typeof darkOrPalette === 'object' && darkOrPalette !== null) ? darkOrPalette : null;
+    const darkColor = palette ? null : darkOrPalette;
     for (let r = 0; r < rows.length; r++) {
       const row = rows[r];
       for (let c = 0; c < row.length; c++) {
-        const ch = row.charCodeAt(c);
-        // '#' = 35, 'o' = 111, '.' = 46
-        if (ch === 35) {
-          ctx.fillStyle = darkColor;
-          ctx.fillRect(x + c * scale, y + r * scale, scale, scale);
-        } else if (ch === 111 && lightColor) {
-          ctx.fillStyle = lightColor;
-          ctx.fillRect(x + c * scale, y + r * scale, scale, scale);
+        const ch = row.charAt(c);
+        if (ch === '.') continue;
+        let color = null;
+        if (palette) {
+          color = palette[ch];
+        } else if (ch === '#') {
+          color = darkColor;
+        } else if (ch === 'o') {
+          color = lightColor;
         }
+        if (!color) continue;
+        ctx.fillStyle = color;
+        ctx.fillRect(x + c * scale, y + r * scale, scale, scale);
       }
     }
   }

--- a/public/cappy-run.js
+++ b/public/cappy-run.js
@@ -52,6 +52,10 @@
     game.start();
   }
 
+  // Also allow other UI (e.g. the secret bar in the site menu) to launch
+  // the game without needing to dispatch the full Konami sequence.
+  window.addEventListener('cappyrun:launch', launchGame);
+
   // ----------------------------- Sprite data -----------------------------
   // Pixel art encoded as strings. '#' = dark, 'o' = light/fill, '.' = transparent.
   // Mirrors the chunky black-and-white look of the CloseDose capybara logo.

--- a/public/global.css
+++ b/public/global.css
@@ -828,8 +828,8 @@ html[data-theme="dark"] .brand-hero__wordmark {
 .menu-overlay { position: fixed; inset: 0; z-index: 2500; background: rgba(245, 249, 249, 0.98); backdrop-filter: blur(8px); display: grid; place-items: center; opacity: 0; pointer-events: none; transition: opacity 0.25s ease; }
 .menu-overlay.open { opacity: 1; pointer-events: auto; }
 .menu-panel { width: min(400px, 90%); text-align: center; }
-.menu-links { display: flex; flex-direction: column; gap: 24px; margin-bottom: 48px; }
-.menu-links a { font-size: 2rem; font-weight: 900; color: var(--ink-900); text-decoration: none; text-transform: uppercase; letter-spacing: 0.05em; transition: transform 0.2s ease, color 0.2s ease; }
+.menu-links { display: flex; flex-direction: column; gap: 14px; margin-bottom: 28px; }
+.menu-links a { font-size: 1.5rem; font-weight: 900; color: var(--ink-900); text-decoration: none; text-transform: uppercase; letter-spacing: 0.05em; transition: transform 0.2s ease, color 0.2s ease; }
 .menu-links a:hover { transform: scale(1.1); color: var(--teal-400); }
 .menu-links a[aria-current="page"] { color: var(--teal-400); pointer-events: none; }
 .close-menu { appearance: none; background: var(--white); border: var(--card-border); border-radius: 999px; padding: 12px 32px; font-weight: 900; text-transform: uppercase; letter-spacing: 0.1em; cursor: pointer; box-shadow: var(--shadow-btn); }
@@ -2766,3 +2766,62 @@ html[data-theme="light"] .menu-theme-btn.is-active {
     left: 0;
   }
 }
+
+
+/* =============================================
+   MENU SECRET BAR — Cappy Run launcher
+   A subtle thick line at the bottom of the menu panel that doubles as a
+   tap target to launch the Cappy Run easter egg on touch devices.
+   ============================================= */
+
+.menu-secret-bar {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 60%;
+  max-width: 220px;
+  height: 32px;
+  margin: 18px auto 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.menu-secret-bar::before {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(15, 44, 42, 0.18);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.menu-secret-bar:hover::before,
+.menu-secret-bar:focus-visible::before {
+  background: rgba(15, 44, 42, 0.32);
+  transform: scaleY(1.25);
+}
+
+.menu-secret-bar:active::before {
+  background: var(--teal-400, #24a687);
+  transform: scaleY(1.4);
+}
+
+.menu-secret-bar:focus-visible {
+  outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .menu-secret-bar::before { background: rgba(255, 255, 255, 0.14); }
+  .menu-secret-bar:hover::before,
+  .menu-secret-bar:focus-visible::before { background: rgba(255, 255, 255, 0.28); }
+}
+
+html[data-theme="dark"] .menu-secret-bar::before { background: rgba(255, 255, 255, 0.14); }
+html[data-theme="dark"] .menu-secret-bar:hover::before,
+html[data-theme="dark"] .menu-secret-bar:focus-visible::before { background: rgba(255, 255, 255, 0.28); }

--- a/public/global.js
+++ b/public/global.js
@@ -97,6 +97,27 @@
       picker.querySelectorAll('.menu-theme-btn').forEach(function (btn) {
         btn.addEventListener('click', function () { applyTheme(btn.dataset.themeChoice); });
       });
+
+      // Subtle launcher for the Cappy Run easter egg (tap-friendly on mobile,
+      // since the Konami code isn't reachable from a touchscreen). The bar is
+      // appended last so it sits at the bottom of the menu panel.
+      const secretBar = document.createElement('button');
+      secretBar.type = 'button';
+      secretBar.className = 'menu-secret-bar';
+      secretBar.setAttribute('aria-label', 'Launch Cappy Run');
+      secretBar.addEventListener('click', function () {
+        window.dispatchEvent(new Event('cappyrun:launch'));
+        const menuOverlay = document.getElementById('siteMenu');
+        const menuBtn = document.querySelector('.menu-btn');
+        if (menuOverlay && menuOverlay.classList.contains('open')) {
+          menuOverlay.classList.remove('open');
+          setTimeout(function () {
+            if (!menuOverlay.classList.contains('open')) menuOverlay.hidden = true;
+          }, 250);
+          if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
+        }
+      });
+      menuPanel.appendChild(secretBar);
     }
 
     updateThemeUI();
@@ -266,8 +287,9 @@
   // --- Cappy Run (Konami code easter egg) ---
   // Lazy-load the game module + styles on the first DOMContentLoaded so the
   // Konami code listener is wired up across the site without bloating any page.
+  let cappyRunLoadPromise = null;
   function loadCappyRun() {
-    if (document.getElementById('cappy-run-css')) return;
+    if (cappyRunLoadPromise) return cappyRunLoadPromise;
     const link = document.createElement('link');
     link.id = 'cappy-run-css';
     link.rel = 'stylesheet';
@@ -276,8 +298,21 @@
     const script = document.createElement('script');
     script.src = 'cappy-run.js';
     script.defer = true;
+    cappyRunLoadPromise = new Promise(function (resolve) {
+      script.addEventListener('load', resolve);
+      script.addEventListener('error', resolve);
+    });
     document.head.appendChild(script);
+    return cappyRunLoadPromise;
   }
+  // Bridge: if a launch event fires before cappy-run.js has registered its
+  // own listener, ensure the module is loaded and then re-dispatch.
+  window.addEventListener('cappyrun:launch', function () {
+    if (window.__cappyRunInstalled) return;
+    loadCappyRun().then(function () {
+      window.dispatchEvent(new Event('cappyrun:launch'));
+    });
+  });
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', loadCappyRun);
   } else {


### PR DESCRIPTION
## **User description**
## Summary
- Adds a hidden, Chrome-Dino-style endless runner ("Cappy Run") starring a brown pixel-art capybara that overlays the bottom of any CloseDose page.
- Trigger anywhere on the site via the Konami code (`↑ ↑ ↓ ↓ ← → ← → B A Enter`) or — for touchscreens — by tapping the subtle thick bar at the bottom of the site menu.
- Controls: `Space` / `↑` jump, `↓` duck (fast-fall mid-air), tap/click jumps on mobile, `Esc` (or the × button) exits. High score persists in `localStorage`.
- Menu refresh: tightened vertical spacing and link size in the menu panel so it feels more compact.

## Implementation notes
- `public/cappy-run.js` is a self-contained module: Konami listener, canvas game loop, multi-color pixel sprites (brown body, light tan highlights, dark outline, glinting eye, small upturned smile). `drawSprite` accepts a `{char → color}` palette so the same renderer covers the cappy plus the obstacles, parrots, and clouds.
- `public/cappy-run.css` styles the bottom-anchored overlay frame; it adapts to `data-theme`.
- `public/global.js` lazy-loads the module + CSS on first DOMContentLoaded, injects the secret tap-bar into the site menu, and bridges a `cappyrun:launch` event so any UI (or future caller) can start the game.
- `public/global.css` tightens menu spacing (`gap: 24px → 14px`, link size `2rem → 1.5rem`) and styles the new menu secret bar with hover/focus/active states for both light and dark themes.
- No new image assets — all art is encoded inline as pixel strings.
- Background tries to evoke a capybara habitat: pebble ground line with scrolling water-ripple curves and drifting clouds. Flying parrot obstacles unlock after ~800 px so the early game stays beatable.

## Test plan
- [ ] Load `public/index.html` in a browser; from any focus state, type `↑ ↑ ↓ ↓ ← → ← → B A Enter` → overlay appears at the bottom.
- [ ] On mobile/touch: open the site menu, tap the thick bar near the bottom of the menu panel → game launches and the menu closes.
- [ ] `Space` / `↑` jumps; `↓` ducks; airborne `↓` triggers fast-fall.
- [ ] Hitting an obstacle shows GAME OVER; `Space` restarts; `Esc` (or ×) exits and restores normal page interaction.
- [ ] High score persists across reloads via `localStorage` (`cappyRun.hi`).
- [ ] Spot-check the easter egg on `dashboard.html`, `dosing-guide.html`, etc. (any page that loads `global.js`).
- [ ] Toggle dark mode → both the menu and the game palette switch accordingly.
- [ ] Typing in form inputs (e.g. the login email) does not accidentally trigger the game.


---
_Generated by [Claude Code](https://claude.ai/code/session_011bV1bMGz7pcryykDY2hFZ1)_


___

## **CodeAnt-AI Description**
**Make Cappy Run easier to launch on touch and refresh Cappy's look**

### What Changed
- Added a subtle bar at the bottom of the site menu that opens Cappy Run with a tap, giving mobile users a direct way to reach the easter egg.
- Cappy Run now loads and starts reliably even if the launch action happens before the game is ready.
- Updated Cappy's sprites to a full-color brown capybara with a happier face, while keeping the run, jump, and duck poses consistent.
- Made the site menu feel more compact by reducing link size and spacing.

### Impact
`✅ Easier mobile access to the easter egg`
`✅ Fewer missed launches on slower page loads`
`✅ Clearer, more recognizable Cappy character`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
