### PR TITLE
Cappy Run touch controls + home layout & disclaimer pill

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -139,12 +139,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider.</p>
             <ul>
               <li>Always use the dosing device (syringe or cup) that came with the medication.</li>
@@ -153,6 +155,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 

--- a/public/cappy-run.css
+++ b/public/cappy-run.css
@@ -102,3 +102,53 @@
   #cappyRunOverlay .cappy-run-topbar { font-size: 11px; }
   #cappyRunOverlay .cappy-run-hint { display: none; }
 }
+
+/* On-screen touch controls — hidden by default, shown on touch devices in
+   portrait so the runner is playable without a keyboard. */
+#cappyRunOverlay .cappy-run-touch { display: none; }
+
+@media (pointer: coarse) and (orientation: portrait) {
+  #cappyRunOverlay .cappy-run-touch {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 33vh;
+    padding: 0 20px;
+    pointer-events: none;
+    z-index: 100001;
+  }
+
+  #cappyRunOverlay .cappy-touch-btn {
+    pointer-events: auto;
+    width: 78px;
+    height: 78px;
+    border-radius: 50%;
+    border: 2px solid rgba(47, 93, 58, 0.5);
+    background: rgba(255, 255, 255, 0.55);
+    color: #2f5d3a;
+    font-size: 36px;
+    font-weight: 700;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    backdrop-filter: blur(4px);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+    -webkit-tap-highlight-color: transparent;
+    touch-action: none;
+    user-select: none;
+  }
+
+  #cappyRunOverlay .cappy-touch-btn:active {
+    background: rgba(255, 255, 255, 0.85);
+    transform: scale(0.94);
+  }
+
+  [data-theme='dark'] #cappyRunOverlay .cappy-touch-btn {
+    background: rgba(20, 32, 26, 0.6);
+    border-color: rgba(111, 191, 133, 0.5);
+    color: #9adfb0;
+  }
+}

--- a/public/cappy-run.js
+++ b/public/cappy-run.js
@@ -332,6 +332,58 @@
     frame.appendChild(topbar);
     frame.appendChild(wrap);
     overlay.appendChild(frame);
+
+    // On-screen touch controls (mobile / portrait): ↑ jumps, ↓ ducks. Placed
+    // about a third of the way up the screen so thumbs can reach them while the
+    // game frame sits at the bottom. Hidden on non-touch devices via CSS.
+    const controls = document.createElement('div');
+    controls.className = 'cappy-run-touch';
+
+    const downBtn = document.createElement('button');
+    downBtn.type = 'button';
+    downBtn.className = 'cappy-touch-btn cappy-touch-btn--down';
+    downBtn.setAttribute('aria-label', 'Duck');
+    downBtn.innerHTML = '<span aria-hidden="true">↓</span>';
+
+    const upBtn = document.createElement('button');
+    upBtn.type = 'button';
+    upBtn.className = 'cappy-touch-btn cappy-touch-btn--up';
+    upBtn.setAttribute('aria-label', 'Jump');
+    upBtn.innerHTML = '<span aria-hidden="true">↑</span>';
+
+    upBtn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (this.state === 'over') {
+        this._reset();
+        this.state = 'playing';
+      } else {
+        this._jump();
+        this.keys.jump = true;
+      }
+    });
+    const endJump = () => { this.keys.jump = false; };
+    upBtn.addEventListener('pointerup', endJump);
+    upBtn.addEventListener('pointercancel', endJump);
+    upBtn.addEventListener('pointerleave', endJump);
+
+    downBtn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.keys.duck = true;
+      if (this.cappy && !this.cappy.onGround) {
+        this.cappy.vy = Math.max(this.cappy.vy, 900);
+      }
+    });
+    const endDuck = () => { this.keys.duck = false; };
+    downBtn.addEventListener('pointerup', endDuck);
+    downBtn.addEventListener('pointercancel', endDuck);
+    downBtn.addEventListener('pointerleave', endDuck);
+
+    controls.appendChild(downBtn);
+    controls.appendChild(upBtn);
+    overlay.appendChild(controls);
+
     document.body.appendChild(overlay);
 
     // Touch / click on canvas = jump (mobile-friendly).

--- a/public/contact.html
+++ b/public/contact.html
@@ -88,12 +88,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider.</p>
             <ul>
               <li>Always use the dosing device (syringe or cup) that came with the medication.</li>
@@ -102,6 +104,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 

--- a/public/donations.html
+++ b/public/donations.html
@@ -94,12 +94,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider.</p>
             <ul>
               <li>Always use the dosing device (syringe or cup) that came with the medication.</li>
@@ -108,6 +110,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -448,12 +448,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider.</p>
             <ul>
               <li>Always use the dosing device (syringe or cup) that came with the medication.</li>
@@ -462,6 +464,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 

--- a/public/global.css
+++ b/public/global.css
@@ -404,7 +404,7 @@ html[data-theme="dark"] .brand-hero__wordmark {
 .info-column {
   display: flex;
   flex-direction: column;
-  gap: clamp(12px, 2vw, 16px);
+  gap: clamp(16px, 2.5vw, 24px);
 }
 
 .calculator-column {
@@ -627,8 +627,87 @@ html[data-theme="dark"] .brand-hero__wordmark {
 .donate-link--kofi { color: #29abe0 !important; }
 .donate-link--givebutter { color: #e05a47 !important; }
 
-/* --- Disclaimer Card --- */
-.card--disclaimer { color: var(--ink-900); }
+/* --- Disclaimer Card (collapsible pill) --- */
+.card--disclaimer {
+  color: var(--ink-900);
+  display: grid;
+  justify-items: center;
+  transition: background 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease,
+    padding 0.4s ease, backdrop-filter 0.4s ease;
+}
+
+/* Collapsed: strip the card chrome so only the pill shows. */
+.card--disclaimer:not(.is-expanded) {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  padding: 6px;
+}
+
+.card--disclaimer.is-expanded {
+  justify-items: stretch;
+}
+
+.disclaimer-pill {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 24px;
+  border-radius: 999px;
+  border: 1.5px solid rgba(139, 17, 17, 0.32);
+  background: rgba(139, 17, 17, 0.08);
+  color: #8b1111;
+  font-weight: 900;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+.disclaimer-pill::before {
+  content: "!";
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #8b1111;
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+.disclaimer-pill:hover,
+.disclaimer-pill:focus-visible {
+  background: rgba(139, 17, 17, 0.14);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(139, 17, 17, 0.18);
+  outline: none;
+}
+.card--disclaimer.is-expanded .disclaimer-pill {
+  display: none;
+}
+
+/* Body wrapper expands smoothly via grid-template-rows. */
+.disclaimer-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  width: 100%;
+  opacity: 0;
+  transition: grid-template-rows 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s ease;
+}
+.card--disclaimer.is-expanded .disclaimer-body {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+.disclaimer-body__inner {
+  overflow: hidden;
+  min-height: 0;
+  display: grid;
+  gap: 14px;
+}
+
 .disclaimer-header {
   display: flex;
   align-items: center;
@@ -651,24 +730,7 @@ html[data-theme="dark"] .brand-hero__wordmark {
   font-weight: 900;
   flex: 1 1 auto;
 }
-.disclaimer-toggle {
-  appearance: none;
-  border: 1px solid rgba(15, 44, 42, 0.2);
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--ink-900);
-  padding: 8px 16px;
-  border-radius: 999px;
-  font-weight: 800;
-  font-size: 0.85rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 0.15s ease, transform 0.15s ease;
-}
-.disclaimer-toggle:hover { background: #fff; transform: translateY(-1px); }
-.card--disclaimer.is-expanded .disclaimer-toggle { display: none; }
 .disclaimer-content {
-  margin-top: 16px;
   padding-top: 16px;
   border-top: 1px solid rgba(15, 44, 42, 0.12);
   display: grid;
@@ -699,6 +761,12 @@ html[data-theme="dark"] .brand-hero__wordmark {
   cursor: pointer;
 }
 .disclaimer-close:hover { background: rgba(15, 44, 42, 0.06); }
+
+@media (prefers-reduced-motion: reduce) {
+  .card--disclaimer,
+  .disclaimer-body,
+  .disclaimer-pill { transition: none; }
+}
 
 /* --- Header link wrapper --- */
 .header-link { display: block; line-height: 0; }
@@ -1848,8 +1916,8 @@ html[data-theme="dark"] .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
   align-items: center;
   gap: 14px;
   padding: 14px 18px;
-  background: rgba(255, 255, 255, 0.82);
-  border: 1.5px solid rgba(36,166,135,0.42);
+  background: var(--card-bg);
+  border: var(--card-border);
   border-radius: 14px;
   color: var(--ink-900);
   text-decoration: none;
@@ -1858,27 +1926,10 @@ html[data-theme="dark"] .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-@media (prefers-color-scheme: dark) {
-  .cross-link-card {
-    background: rgba(36,166,135,0.22);
-    border-color: rgba(36,166,135,0.45);
-  }
-}
-
-html[data-theme="dark"] .cross-link-card {
-  background: rgba(36,166,135,0.22);
-  border-color: rgba(36,166,135,0.45);
-}
-
-html[data-theme="light"] .cross-link-card {
-  background: rgba(255, 255, 255, 0.82);
-  border-color: rgba(36,166,135,0.42);
-}
-
 .cross-link-card:hover, .cross-link-card:focus-visible {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 8px 24px rgba(36,166,135,0.22);
+  border-color: var(--teal-400);
+  box-shadow: var(--shadow-card);
   outline: none;
 }
 
@@ -2290,27 +2341,7 @@ html[data-theme="light"] .cross-link-card {
 }
 
 /* Secondary cross-link card (subtle teal tint) */
-.cross-link-card--secondary {
-  background: rgba(255, 255, 255, 0.76);
-  border-color: rgba(13,143,138,0.38);
-}
-
-@media (prefers-color-scheme: dark) {
-  .cross-link-card--secondary {
-    background: rgba(13,143,138,0.20);
-    border-color: rgba(13,143,138,0.4);
-  }
-}
-
-html[data-theme="dark"] .cross-link-card--secondary {
-  background: rgba(13,143,138,0.20);
-  border-color: rgba(13,143,138,0.4);
-}
-
-html[data-theme="light"] .cross-link-card--secondary {
-  background: rgba(255, 255, 255, 0.76);
-  border-color: rgba(13,143,138,0.38);
-}
+/* Secondary cross-link card shares the standard card background. */
 
 /* =============================================
    UX POLISH — "RUNNING ON FUMES" IMPROVEMENTS

--- a/public/global.js
+++ b/public/global.js
@@ -208,10 +208,13 @@
   }
 
   // --- Disclaimer Expansion Logic ---
+  // The card sits at the very bottom as a collapsed "DISCLAIMER" pill and
+  // smoothly expands into the full card when the user reaches the page end
+  // (or taps the pill). A manual close keeps it collapsed until re-triggered.
   const disclaimerCard = document.querySelector('.card--disclaimer');
   if (disclaimerCard) {
-    const content = disclaimerCard.querySelector('.disclaimer-content');
-    const toggleBtn = disclaimerCard.querySelector('.disclaimer-toggle');
+    const panel = disclaimerCard.querySelector('.disclaimer-body');
+    const pill = disclaimerCard.querySelector('.disclaimer-pill');
     const closeBtn = disclaimerCard.querySelector('.disclaimer-close');
     const root = document.documentElement;
     let manualDismiss = false;
@@ -219,16 +222,18 @@
     const setExpanded = (expanded, manual = false) => {
       disclaimerCard.classList.toggle('is-expanded', expanded);
       disclaimerCard.setAttribute('aria-expanded', expanded);
-      if (content) content.hidden = !expanded;
-      if (toggleBtn) toggleBtn.setAttribute('aria-expanded', String(expanded));
+      if (panel) panel.inert = !expanded;
+      if (pill) pill.setAttribute('aria-expanded', String(expanded));
       if (expanded) {
         manualDismiss = false;
         if (closeBtn) closeBtn.focus({ preventScroll: true });
       } else if (manual) {
         manualDismiss = true;
-        if (toggleBtn) toggleBtn.focus({ preventScroll: true });
+        if (pill) pill.focus({ preventScroll: true });
       }
     };
+
+    if (panel) panel.inert = true;
 
     window.addEventListener('scroll', () => {
       const reachedEnd = window.innerHeight + window.scrollY >= root.scrollHeight - 20;
@@ -237,8 +242,8 @@
       }
     }, { passive: true });
 
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', (e) => {
+    if (pill) {
+      pill.addEventListener('click', (e) => {
         e.stopPropagation();
         setExpanded(true, true);
       });
@@ -250,6 +255,31 @@
         setExpanded(false, true);
       });
     }
+  }
+
+  // --- Sidebar alignment: start the info column at the calculator card ---
+  // On the desktop grid the helper cards should begin level with the top of
+  // the calculator card rather than the brand hero above it.
+  const infoColumn = document.querySelector('.info-column');
+  const brandHero = document.querySelector('.calculator-column .brand-hero');
+  if (infoColumn && brandHero) {
+    const desktop = window.matchMedia('(min-width: 1024px)');
+    const syncSidebar = () => {
+      if (desktop.matches) {
+        const colGap = parseFloat(getComputedStyle(brandHero.parentElement).rowGap) || 0;
+        infoColumn.style.marginTop = (brandHero.offsetHeight + colGap) + 'px';
+      } else {
+        infoColumn.style.marginTop = '';
+      }
+    };
+    syncSidebar();
+    window.addEventListener('resize', syncSidebar);
+    window.addEventListener('load', syncSidebar);
+    if (window.ResizeObserver) {
+      new ResizeObserver(syncSidebar).observe(brandHero);
+    }
+    const heroImg = brandHero.querySelector('img');
+    if (heroImg && !heroImg.complete) heroImg.addEventListener('load', syncSidebar);
   }
 
   // --- Card Intersection Observer for Animations ---

--- a/public/index.html
+++ b/public/index.html
@@ -145,17 +145,21 @@
         </section>
 
         <section class="card card--disclaimer" id="disclaimer-card" aria-expanded="false" aria-labelledby="disclaimer-heading">
-          <div class="disclaimer-header">
-            <span class="disclaimer-eyebrow">Important</span>
-            <h2 id="disclaimer-heading">Disclaimer &amp; medical safety</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
-          </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
-            <p>This calculator is for educational support only and does not replace guidance from your pediatrician or pharmacist. Always confirm dosing before administering medication.</p>
-            <p>If your child is 0–2 months of age or has any complex medical history, please consult with your medical care team prior to use.</p>
-            <p class="disclaimer-seek-care"><strong>When to seek care:</strong> Call 911 or your pediatrician for trouble breathing, persistent vomiting, or seizures.</p>
-            <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
-            <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
+              <div class="disclaimer-header">
+                <span class="disclaimer-eyebrow">Important</span>
+                <h2 id="disclaimer-heading">Disclaimer &amp; medical safety</h2>
+              </div>
+              <div class="disclaimer-content">
+                <p>This calculator is for educational support only and does not replace guidance from your pediatrician or pharmacist. Always confirm dosing before administering medication.</p>
+                <p>If your child is 0–2 months of age or has any complex medical history, please consult with your medical care team prior to use.</p>
+                <p class="disclaimer-seek-care"><strong>When to seek care:</strong> Call 911 or your pediatrician for trouble breathing, persistent vomiting, or seizures.</p>
+                <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
+                <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+              </div>
+            </div>
           </div>
         </section>
       </div>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -472,12 +472,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider or pharmacist before use.</p>
             <ul>
               <li>Always use the measuring device (oral syringe or dosing cup) that came with the medication — household spoons are not accurate.</li>
@@ -487,6 +489,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -122,12 +122,14 @@
 
         <!-- Disclaimer -->
         <section class="card card--disclaimer" id="disclaimer-card" aria-labelledby="disclaimer-heading" aria-expanded="false">
+          <button type="button" class="disclaimer-pill" aria-controls="disclaimer-panel" aria-expanded="false">Disclaimer</button>
+          <div class="disclaimer-body" id="disclaimer-panel">
+            <div class="disclaimer-body__inner">
           <div class="disclaimer-header">
             <span class="disclaimer-eyebrow">Disclaimer</span>
             <h2 id="disclaimer-heading">Medication Safety &amp; Usage</h2>
-            <button type="button" class="disclaimer-toggle" aria-controls="disclaimer-panel" aria-expanded="false">Read</button>
           </div>
-          <div class="disclaimer-content" id="disclaimer-panel" hidden>
+          <div class="disclaimer-content">
             <p><strong>This tool does not provide medical advice.</strong> The dosing information is for educational purposes only and should be verified with a healthcare provider.</p>
             <ul>
               <li>If your baby is gaining or losing weight unusually quickly, contact your pediatrician.</li>
@@ -136,6 +138,8 @@
             </ul>
             <a class="disclaimer-link" href="/legal/disclaimer">Read the full disclaimer →</a>
             <button type="button" class="disclaimer-close" aria-label="Close disclaimer">Close</button>
+          </div>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- **Cappy Run mobile controls:** added on-screen ↑ (jump) and ↓ (duck) buttons that appear on touch devices in portrait, positioned at ~1/3 of the viewport height above the game frame so the runner is playable without a keyboard.
- **Sidebar alignment:** on the desktop grid the info column now starts level with the top of the calculator card instead of the brand hero (computed in `global.js`, kept in sync on resize / image load).
- **Card spacing:** evened out the gap between sidebar cards to match the rest of the layout.
- **Card backgrounds:** the weighing-guide and measuring-guide cross-link cards now use the standard `--card-bg` / `--card-border` so they match the other cards (light & dark).
- **Disclaimer pill:** the disclaimer is now the bottom-most card, rendered as a collapsed "DISCLAIMER" pill that smoothly expands (animated `grid-template-rows`) when the user scrolls to the very bottom of the page, or taps the pill. Applied site-wide since the markup/CSS/JS are shared.

## Test plan
- [x] Mobile portrait (390×844): Cappy Run shows two touch buttons at ~33vh; ↑ jumps / restarts, ↓ ducks.
- [x] Desktop (1280): sidebar starts at calculator-card top; guide cards match other card backgrounds.
- [x] Disclaimer loads as a collapsed "DISCLAIMER" pill and auto-expands on reaching the page bottom; collapses via Close.
- [x] No app-originated console errors (only external CDN cert warnings in the sandbox).
- [ ] Verify on a physical phone / real browsers.

https://claude.ai/code/session_017UUkyeDaCrDoTNcvd9Jd4p

---
_Generated by [Claude Code](https://claude.ai/code/session_017UUkyeDaCrDoTNcvd9Jd4p)_