### PR TITLE
Remove EnteralID nav, link hero blurb to GiveButter, normalize Dosing Guide color

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -181,7 +181,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about" aria-current="page">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>

--- a/public/contact.html
+++ b/public/contact.html
@@ -130,7 +130,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact" aria-current="page">Contact</a>

--- a/public/donations.html
+++ b/public/donations.html
@@ -136,7 +136,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support" aria-current="page">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -490,7 +490,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing" aria-current="page">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>

--- a/public/global.css
+++ b/public/global.css
@@ -384,6 +384,27 @@ html[data-theme="dark"] .brand-hero__wordmark {
   color: var(--ink-900);
 }
 
+.brand-blurb--donate {
+  appearance: none;
+  width: 100%;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.brand-blurb--donate:hover,
+.brand-blurb--donate:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--teal-400);
+  box-shadow: var(--shadow-card);
+  outline: none;
+}
+.brand-blurb--donate .brand-blurb__eyebrow,
+.brand-blurb--donate .brand-blurb__title,
+.brand-blurb--donate .brand-blurb__body {
+  display: block;
+}
+
 /* --- Layout: single-column scrolling --- */
 .layout {
   width: min(720px, 100%);
@@ -2434,8 +2455,6 @@ html[data-theme="dark"] .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
   color: var(--ink-900);
 }
 
-/* Navigation: highlight dosing guide link color */
-.nav-dosing { color: var(--teal-500) !important; }
 
 /* =============================================
    HOVER GUARDS — prevent sticky hover on touch

--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,14 @@
 
           <div class="calculator-widget-host" id="calculator-card" data-calculator-root></div>
 
+          <givebutter-widget id="gOeyDj">
+            <button type="button" class="card brand-blurb brand-blurb--donate" aria-labelledby="brand-blurb-heading" aria-label="Donate to CloseDose via GiveButter">
+              <span class="brand-blurb__eyebrow">Built by pediatric physicians · Free for families</span>
+              <span id="brand-blurb-heading" class="brand-blurb__title">Confident pediatric dosing in seconds.</span>
+              <span class="brand-blurb__body">Enter your child's age and weight to get accurate acetaminophen and ibuprofen dosing — no account, no math, no guesswork.</span>
+            </button>
+          </givebutter-widget>
+
           <p class="calculator-trust">
             CloseDose is free, ad-free, and reviewed by an actively practicing pediatric emergency physician.
             <a href="about.html">Learn more about CloseDose →</a>
@@ -65,12 +73,6 @@
         </div>
 
         <aside class="info-column" aria-label="How to use and safety reminders">
-          <section class="card brand-blurb" aria-labelledby="brand-blurb-heading">
-            <p class="brand-blurb__eyebrow">Built by pediatric physicians · Free for families</p>
-            <h2 id="brand-blurb-heading" class="brand-blurb__title">Confident pediatric dosing in seconds.</h2>
-            <p class="brand-blurb__body">Enter your child's age and weight to get accurate acetaminophen and ibuprofen dosing — no account, no math, no guesswork.</p>
-          </section>
-
           <a class="cross-link-card" href="weighing-guide.html" aria-label="Open the weighing guide for infants and young children">
             <span class="cross-link-card__emoji" aria-hidden="true">⚖️</span>
             <span class="cross-link-card__body">
@@ -186,7 +188,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -515,7 +515,6 @@
         <a href="medication-guides.html" class="nav-guides" aria-current="page">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -164,7 +164,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="weighing-guide.html" class="nav-weighing" aria-current="page">Weighing Guide</a>
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
-        <a href="https://enteral-id.click" class="nav-enteral" target="_blank" rel="noopener">EnteralID</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
         <a href="contact.html" class="nav-contact">Contact</a>


### PR DESCRIPTION
## Summary
- Removed the EnteralID link from the site menu across every page that includes it.
- Removed the special teal color rule on `.nav-dosing` so the Dosing Guide menu link matches the rest of the menu items.
- Moved the "Confident pediatric dosing in seconds." card so it immediately follows the calculator (above the trust line), and wrapped it in the existing GiveButter widget (`gOeyDj`) so tapping/clicking it opens the same donation popup as the donate button further down the page.
- Added a `.brand-blurb--donate` button variant in `global.css` for the tappable state (button reset + hover/focus lift, matching the existing cross-link cards).

## Test plan
- [ ] On `index.html`, confirm the blurb card now sits directly below the calculator widget and above the "CloseDose is free, ad-free..." trust line.
- [ ] Tap/click the blurb card and confirm the GiveButter donation popup opens (same popup as the lower donate button).
- [ ] Open the site menu and verify EnteralID is gone, and that Dosing Guide is the same color as the other menu links.
- [ ] Repeat the menu check on About, Contact, Donations, Dosing Guide, Medication Guides, and Weighing Guide pages.

https://claude.ai/code/session_0185WeucF6b9TLm8iVrfJTYv

---
_Generated by [Claude Code](https://claude.ai/code/session_0185WeucF6b9TLm8iVrfJTYv)_