### PR TITLE
Emphasize calculator step bubbles; remove How-to card and Start Here pill

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -84,15 +84,6 @@
             <span class="cross-link-card__arrow" aria-hidden="true">→</span>
           </a>
 
-          <section class="card info-card info-card--steps">
-            <h2 class="info-card-title">How to use CloseDose</h2>
-            <ol class="info-steps">
-              <li><span class="step-num">1</span><span><strong>Pick an age group.</strong> Tap the band that matches your child.</span></li>
-              <li><span class="step-num">2</span><span><strong>Enter the weight.</strong> Pounds or kilograms — both work.</span></li>
-              <li><span class="step-num">3</span><span><strong>Calculate.</strong> Get a single recommended dose with the safest interval.</span></li>
-            </ol>
-          </section>
-
           <section class="card info-card info-card--safety">
             <h2 class="info-card-title">Safety quick-reference</h2>
             <ul class="info-list">

--- a/public/widget/close-dose-calculator.js
+++ b/public/widget/close-dose-calculator.js
@@ -5,9 +5,7 @@
 
   const DEFAULT_STRINGS = {
     title: 'Fever/Pain Medication Dosing',
-    header: {
-      eyebrow: 'Start here',
-    },
+    header: {},
     form: {
       ageLabel: 'Step 1: Tap an age group',
       ageGroupAria: 'Select patient age',
@@ -255,7 +253,7 @@
     .cdcalc-step-callout--step {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 14px;
     }
 
     .cdcalc-step-badge {
@@ -263,20 +261,21 @@
       align-items: center;
       justify-content: center;
       flex: none;
-      width: 30px;
-      height: 30px;
+      width: 44px;
+      height: 44px;
       border-radius: 999px;
       background: #24a687;
       color: #ffffff;
-      border: 2px solid #0f2c2a;
-      box-shadow: 0 2px 0 rgba(15, 44, 42, 0.25);
-      font-size: 0.95rem;
+      border: 3px solid #0f2c2a;
+      box-shadow: 0 3px 0 rgba(15, 44, 42, 0.25);
+      font-size: 1.35rem;
       font-weight: 900;
       letter-spacing: 0;
     }
 
     .cdcalc-step-text {
       display: inline-block;
+      font-size: 1.2rem;
     }
 
     .cdcalc-segmented {
@@ -438,7 +437,7 @@
     }
 
     .cdcalc-step-callout--step {
-      justify-content: center;
+      justify-content: flex-start;
     }
 
     .cdcalc-button {


### PR DESCRIPTION
## Summary

Refocuses the home page on the calculator's built-in 1/2/3 step flow instead of a separate explainer card.

- **Removed** the "How to use CloseDose" steps card from the info column — the calculator's own numbered steps now carry that guidance, so reading the page top-to-bottom makes the starting point obvious.
- **Removed** the "Start here" eyebrow pill from the calculator header — opening the calculator and reading down is intuitive enough.
- **Emphasized** the 1/2/3 step badge bubbles (larger circles, thicker border) and increased the step text size.
- **Aligned step 3** ("Calculate!") to the left to match steps 1 & 2, which were previously left-aligned while step 3 was centered.

## Files changed
- `public/index.html` — removed the `info-card--steps` section
- `public/widget/close-dose-calculator.js` — dropped the header eyebrow string; enlarged step badges/text; left-aligned the step 3 callout

https://claude.ai/code/session_01Y3zvqVByQscSJh3j9PJYcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3zvqVByQscSJh3j9PJYcT)_