### PR TITLE
Polish home layout: full-width disclaimer, centered wordmark, outlined top-right menu

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -178,7 +178,7 @@ header {
 
 .menu-btn {
   appearance: none;
-  border: var(--card-border);
+  border: 2px solid var(--ink-900);
   border-radius: 999px;
   background: var(--white);
   color: var(--ink-900);
@@ -199,6 +199,14 @@ header {
   left: clamp(18px, 5vw, 48px);
   z-index: 1200;
   height: 56px;
+}
+
+/* Desktop with sidebar: dock the menu pill to the top-right corner. */
+@media (min-width: 1024px) {
+  .menu-btn {
+    left: auto;
+    right: clamp(18px, 5vw, 48px);
+  }
 }
 
 .menu-btn .label { display: inline; }
@@ -293,7 +301,8 @@ main {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(6px, 1.5vw, 16px) 0 clamp(2px, 0.8vw, 8px);
+  text-align: center;
+  padding: clamp(10px, 2vw, 24px) 0 clamp(8px, 1.6vw, 18px);
   margin: 0 auto;
   animation: slam-in 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
 }
@@ -534,33 +543,39 @@ html[data-theme="dark"] .brand-hero__wordmark {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
     align-items: start;
-    gap: clamp(20px, 2.4vw, 32px);
+    column-gap: clamp(20px, 2.4vw, 32px);
+    row-gap: clamp(12px, 1.6vw, 22px);
+  }
+  /* Brand wordmark spans the full grid so it stays centered on the page
+     rather than over the (left-aligned) calculator column. */
+  .brand-hero {
+    grid-column: 1 / -1;
   }
   .layout--secondary {
     width: min(1140px, 100%);
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
-    align-items: start;
-    gap: clamp(20px, 2.4vw, 32px);
+    display: block;
   }
+  /* Disclaimer card stretches the full width of the content area. */
   .layout--secondary > .card {
-    grid-column: 1;
-    max-width: 720px;
+    width: 100%;
+    max-width: none;
   }
   .calculator-column {
+    grid-column: 1;
     min-width: 0;
     max-width: 720px;
     width: 100%;
     justify-self: start;
   }
   .info-column {
+    grid-column: 2;
     position: sticky;
     top: clamp(20px, 3vw, 32px);
     align-self: start;
   }
   .brand-hero__link {
-    width: 75%;
-    max-width: 560px;
+    width: 60%;
+    max-width: 520px;
   }
 }
 

--- a/public/global.js
+++ b/public/global.js
@@ -257,31 +257,6 @@
     }
   }
 
-  // --- Sidebar alignment: start the info column at the calculator card ---
-  // On the desktop grid the helper cards should begin level with the top of
-  // the calculator card rather than the brand hero above it.
-  const infoColumn = document.querySelector('.info-column');
-  const brandHero = document.querySelector('.calculator-column .brand-hero');
-  if (infoColumn && brandHero) {
-    const desktop = window.matchMedia('(min-width: 1024px)');
-    const syncSidebar = () => {
-      if (desktop.matches) {
-        const colGap = parseFloat(getComputedStyle(brandHero.parentElement).rowGap) || 0;
-        infoColumn.style.marginTop = (brandHero.offsetHeight + colGap) + 'px';
-      } else {
-        infoColumn.style.marginTop = '';
-      }
-    };
-    syncSidebar();
-    window.addEventListener('resize', syncSidebar);
-    window.addEventListener('load', syncSidebar);
-    if (window.ResizeObserver) {
-      new ResizeObserver(syncSidebar).observe(brandHero);
-    }
-    const heroImg = brandHero.querySelector('img');
-    if (heroImg && !heroImg.complete) heroImg.addEventListener('load', syncSidebar);
-  }
-
   // --- Card Intersection Observer for Animations ---
   const observerOptions = { threshold: 0.1 };
   const observer = new IntersectionObserver((entries) => {

--- a/public/index.html
+++ b/public/index.html
@@ -41,21 +41,21 @@
 
     <main>
       <div class="layout layout--grid">
-        <div class="calculator-column">
-          <section class="brand-hero" aria-label="CloseDose">
-            <a href="index.html" class="brand-hero__link" aria-label="CloseDose home">
-              <img
-                src="images/logomark-WC.png"
-                alt="CloseDose — pediatric dosing calculator"
-                class="brand-hero__wordmark"
-                width="3679"
-                height="1744"
-                fetchpriority="high"
-              />
-            </a>
-            <h1 id="hero-heading" class="visually-hidden">CloseDose — confident pediatric dosing in seconds</h1>
-          </section>
+        <section class="brand-hero" aria-label="CloseDose">
+          <a href="index.html" class="brand-hero__link" aria-label="CloseDose home">
+            <img
+              src="images/logomark-WC.png"
+              alt="CloseDose — pediatric dosing calculator"
+              class="brand-hero__wordmark"
+              width="3679"
+              height="1744"
+              fetchpriority="high"
+            />
+          </a>
+          <h1 id="hero-heading" class="visually-hidden">CloseDose — confident pediatric dosing in seconds</h1>
+        </section>
 
+        <div class="calculator-column">
           <div class="calculator-widget-host" id="calculator-card" data-calculator-root></div>
 
           <button type="button" class="card support-care-card" data-gb-account="r8SGiZ0RhFRoIkXu" data-gb-campaign="93Xrjv" data-gb-type="modal" aria-label="Support pediatric care — donate to CloseDose via GiveButter">


### PR DESCRIPTION
## Summary

Desktop layout polish for the home page (`public/index.html`), addressing four requests:

1. **Full-width disclaimer card** — The disclaimer card now stretches the entire width of the content area at the bottom of the page on desktop, in both the single-column ("regular") view and the two-column ("sidebar") view. Previously it was capped at 720px over the left column in the sidebar layout.
2. **Centered CloseDose wordmark** — The brand wordmark was moved out of the calculator column so it spans the full grid row, keeping it centered on the page (rather than centered over the left-aligned calculator column) in the sidebar view. It also gets a bit more vertical breathing room. Mobile and regular-desktop centering are unchanged.
3. **Outlined menu pill** — The Menu button now has a defined 2px outline so it reads as a distinct control.
4. **Top-right menu on desktop w/ sidebar** — When the sidebar is present (≥1024px), the menu pill docks to the top-right corner. Below that breakpoint it stays top-left, and on mobile it remains the bottom-left icon button.

## Implementation notes
- `public/index.html`: moved the `.brand-hero` section to be a direct child of `.layout--grid` (sibling of the calculator/info columns).
- `public/global.css`: brand-hero spans `grid-column: 1 / -1` on desktop; `.layout--secondary` disclaimer card goes full width; `.menu-btn` gets a 2px outline and a `min-width: 1024px` rule docking it top-right.
- `public/global.js`: removed the now-unnecessary JS that manually offset the info column to align with the calculator card — with the wordmark in its own full-width row, the two columns align naturally.

## Verification
Rendered and visually checked four states (desktop sidebar top/bottom, desktop regular top/bottom) plus mobile via Playwright screenshots. Pre-existing test failures in `tests/` are unrelated (they reference `i18n/` and `voice.mjs` at the repo root rather than under `public/`, and fail on a clean tree).

https://claude.ai/code/session_018xBDC5cDqm3RMxfDqqC5SR

---
_Generated by [Claude Code](https://claude.ai/code/session_018xBDC5cDqm3RMxfDqqC5SR)_