### PR TITLE
Move Contact to footer, center wordmark, separate appearance settings, fix Cappy Run init

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -233,6 +233,7 @@
 
   <footer class="cd-footer" role="contentinfo">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -250,7 +251,6 @@
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
         <a href="about.html" class="nav-about" aria-current="page">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/cappy-run.js
+++ b/public/cappy-run.js
@@ -1170,6 +1170,10 @@
     this.last = performance.now();
     document.addEventListener('keydown', this._onKeyDown, true);
     document.addEventListener('keyup', this._onKeyUp, true);
+    // Paint the opening (idle) frame synchronously so Cappy is on screen the
+    // instant the overlay appears, rather than waiting for the first
+    // animation-frame callback (which can be a beat late on first launch).
+    try { this._draw(); } catch (_) {}
     this.rafId = requestAnimationFrame(this._tick);
     // Track via GA if present.
     if (window.gtag) {
@@ -1233,11 +1237,23 @@
 
     const wrap = document.createElement('div');
     wrap.className = 'cappy-run-canvas-wrap';
+    // Inline fallback sizing so the canvas always has a real, non-zero
+    // rendered size even on the very first launch — before the async
+    // cappy-run.css has been applied. Without this, some engines compute a
+    // collapsed (0-height) canvas on the first layout pass, which paints the
+    // frame background but clips Cappy and the scenery until a second launch.
+    wrap.style.position = 'relative';
+    wrap.style.width = '100%';
+    wrap.style.aspectRatio = '4 / 1';
+    wrap.style.maxHeight = '220px';
 
     const canvas = document.createElement('canvas');
     canvas.width = this.W;
     canvas.height = this.H;
     canvas.tabIndex = 0;
+    canvas.style.display = 'block';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
 
     // Game-over / high-score panel overlays the canvas.
     const panel = document.createElement('div');
@@ -1473,18 +1489,24 @@
 
   CappyRun.prototype._tick = function (now) {
     if (!this.active) return;
-    const dt = Math.min(0.05, (now - this.last) / 1000);
+    const dt = Math.min(0.05, Math.max(0, (now - this.last) / 1000));
     this.last = now;
-    if (this.state === 'ready') {
-      this.frameTick += dt;
-      this.cappy.idleFrame = Math.floor(this.frameTick * 2) % CAPPY_IDLE_FRAMES.length;
-      this.readyTimer -= dt;
-      if (this.readyTimer <= 0) this.state = 'playing';
-    } else if (this.state === 'playing') {
-      this._update(dt);
+    // Guard the per-frame work so a transient draw/update error can never
+    // permanently freeze the loop (leaving only the background on screen).
+    try {
+      if (this.state === 'ready') {
+        this.frameTick += dt;
+        this.cappy.idleFrame = Math.floor(this.frameTick * 2) % CAPPY_IDLE_FRAMES.length;
+        this.readyTimer -= dt;
+        if (this.readyTimer <= 0) this.state = 'playing';
+      } else if (this.state === 'playing') {
+        this._update(dt);
+      }
+      this._draw();
+    } catch (err) {
+      if (window.console && console.warn) console.warn('Cappy Run frame error', err);
     }
-    this._draw();
-    this.rafId = requestAnimationFrame(this._tick);
+    if (this.active) this.rafId = requestAnimationFrame(this._tick);
   };
 
   CappyRun.prototype._update = function (dt) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -40,6 +40,7 @@
   
   <footer class="cd-footer">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -54,7 +55,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/donations.html
+++ b/public/donations.html
@@ -204,6 +204,7 @@
 
   <footer class="cd-footer" role="contentinfo">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -221,7 +222,6 @@
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support" aria-current="page">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -475,6 +475,7 @@
 
   <footer class="cd-footer" role="contentinfo">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -492,7 +493,6 @@
         <a href="dosing-guide.html" class="nav-dosing" aria-current="page">Dosing Guide</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/global.css
+++ b/public/global.css
@@ -163,17 +163,22 @@ select[hidden] {
 header {
   position: relative;
   z-index: 1000;
-  width: min(720px, 100%);
+  width: 100%;
   margin: 0 auto;
-  padding: clamp(14px, 3vw, 26px) 0 clamp(6px, 2vw, 14px);
+  padding: clamp(14px, 3vw, 26px) clamp(16px, 5vw, 48px) clamp(6px, 2vw, 14px);
   display: flex;
+  align-items: center;
   justify-content: center;
 }
 
+/* Keep the wordmark consistently centered and sized across every page. The
+   menu button is fixed-position (out of flow), so the wordmark is the only
+   in-flow child and stays optically centered in the viewport. */
 .header-wordmark {
   display: block;
-  width: clamp(160px, 40%, 260px);
+  width: clamp(170px, 42vw, 240px);
   height: auto;
+  margin-inline: auto;
 }
 
 .menu-btn {
@@ -1024,6 +1029,33 @@ html[data-theme="dark"] .brand-hero__wordmark {
   margin: 0 auto;
 }
 .cd-copy { font-weight: 700; margin-bottom: 24px; }
+/* Simple contact button in the footer (replaces the in-menu Contact link). */
+.cd-footer-contact {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 0 auto 24px;
+  padding: 11px 26px;
+  border-radius: 999px;
+  border: 2px solid var(--footer-link);
+  background: transparent;
+  color: var(--footer-link);
+  font-weight: 800;
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+.cd-footer-contact:hover,
+.cd-footer-contact:focus-visible {
+  background: var(--footer-link);
+  color: var(--footer-bg);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(77, 208, 225, 0.28);
+  outline: none;
+}
 .cd-legal { display: flex; justify-content: center; flex-wrap: wrap; gap: 16px; margin-bottom: 24px; }
 .cd-legal a { color: var(--footer-link); text-decoration: none; font-size: 0.9rem; }
 .cd-legal a:hover { text-decoration: underline; }
@@ -2825,21 +2857,60 @@ html[data-theme="light"] .close-menu    { background: var(--white); color: var(-
    MENU THEME PICKER (System / Day / Night)
    ============================================= */
 
+/* Appearance settings sit in their own group, visually separated from the
+   in-line navigation choices by a full-width divider so the toggle never
+   gets mistaken for (or crowds) a menu link. */
 .menu-theme-picker {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 14px;
-  margin-bottom: 28px;
+  gap: 16px;
+  width: 100%;
+  max-width: 320px;
+  margin: 8px auto 24px;
+  padding-top: 26px;
+  border-top: 1px solid rgba(15, 44, 42, 0.16);
 }
 
 .menu-theme-label {
   margin: 0;
-  font-size: 0.68rem;
+  font-size: 0.72rem;
   font-weight: 900;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--on-bg-muted);
+}
+
+@media (prefers-color-scheme: dark) {
+  .menu-theme-picker { border-top-color: rgba(255, 255, 255, 0.16); }
+}
+html[data-theme="dark"] .menu-theme-picker { border-top-color: rgba(255, 255, 255, 0.16); }
+html[data-theme="light"] .menu-theme-picker { border-top-color: rgba(15, 44, 42, 0.16); }
+
+/* Mobile: enlarge the toggle + system button so they're easy to tap without
+   crowding the navigation links above. */
+@media (max-width: 640px) {
+  .menu-theme-picker {
+    gap: 18px;
+    padding-top: 24px;
+    margin-bottom: 20px;
+  }
+  .theme-toggle-wrapper {
+    width: 184px;
+    height: 74px;
+  }
+  .toggle-knob {
+    width: 62px;
+    height: 62px;
+  }
+  /* 184 - 62 knob - 10 margin = 112px travel */
+  input:checked ~ .toggle-knob {
+    transform: translateX(112px);
+  }
+  .menu-theme-btn {
+    font-size: 0.82rem;
+    padding: 11px 24px;
+  }
 }
 
 /* System/auto button below the animated toggle */

--- a/public/index.html
+++ b/public/index.html
@@ -155,6 +155,7 @@
       <img src="images/LOGO-WC.png" alt="CloseDose" class="cd-footer-logo" width="800" height="800" loading="lazy" />
     </a>
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -172,7 +173,6 @@
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/login.html
+++ b/public/login.html
@@ -230,6 +230,7 @@
   
   <footer class="cd-footer">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -244,7 +245,6 @@
         <a href="medication-guides.html" class="nav-guides">Medication Guides</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -500,6 +500,7 @@
 
   <footer class="cd-footer" role="contentinfo">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -517,7 +518,6 @@
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -149,6 +149,7 @@
 
   <footer class="cd-footer" role="contentinfo">
     <p class="cd-copy">2026 CloseDose. All rights reserved.</p>
+    <a class="cd-footer-contact" href="about.html#contact">Contact us</a>
     <nav class="cd-legal cd-legal--full" aria-label="Legal">
       <a href="/legal/terms">Terms</a>
       <a href="/legal/privacy">Privacy</a>
@@ -166,7 +167,6 @@
         <a href="dosing-guide.html" class="nav-dosing">Dosing Guide</a>
         <a href="about.html" class="nav-about">About</a>
         <a href="donations.html" class="nav-support">Support</a>
-        <a href="about.html#contact" class="nav-contact">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>


### PR DESCRIPTION
## Summary

Four UI/UX changes requested:

### 1. Contact moved from menu → footer
- Removed the **Contact** link from the in-menu navigation on every page that has the site menu (`index`, `about`, `donations`, `dosing-guide`, `weighing-guide`, `medication-guides`, `login`, `dashboard`).
- Added a simple **Contact us** button to each page footer (`.cd-footer-contact`, links to `about.html#contact`).

### 2. Wordmark consistently centered
- Standardized the header wordmark sizing (`clamp(170px, 42vw, 240px)`) and spacing, and made the header center it reliably across all pages regardless of the content width below.

### 3. Appearance settings separated & scaled
- The theme picker (day/night slider + **Use system setting** button) is now visually separated from the in-line menu links by a full-width divider and its own spacing, so it no longer crowds or gets mistaken for a nav link.
- Scaled the toggle and system button up on mobile for easier tapping (`@media (max-width: 640px)`), with the knob travel adjusted to match.

### 4. Cappy Run first-launch fix
The game could come up showing only the background with no Cappy and fail to initialize on first launch. Hardened initialization:
- Paint the opening (idle) frame **synchronously** in `start()` so Cappy is on screen immediately instead of waiting for the first animation-frame callback.
- Gave the canvas/wrapper **inline fallback sizing** so it can't collapse to zero height before the async `cappy-run.css` is applied (a likely cause of "background only" on the first run).
- Made the animation loop **self-healing**: a transient per-frame error is caught and logged instead of permanently freezing the loop, and the next frame is always rescheduled while active.

## Testing
- Verified the game still launches via the Konami sequence and runs 120+ frames with no errors under a jsdom harness, both before and after the changes.
- Confirmed all 8 pages have the menu Contact link removed and a footer Contact button added; CSS braces balanced and `cappy-run.js` parses cleanly.

Note: I could not reproduce the exact first-launch freeze in a headless environment (the game loop is logically sound there), so the Cappy fix targets the most likely real-browser causes — first-frame timing and the async-CSS canvas-collapse race — defensively. Worth a quick manual check in a real browser.

https://claude.ai/code/session_012Hr8f6tgwKHp15APWJeVd9

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hr8f6tgwKHp15APWJeVd9)_