### PR TITLE
Centralize site-wide analytics into shared /analytics.js

### DIFF
--- a/public/EnteralID.html
+++ b/public/EnteralID.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>EnteralID | Pediatric Enteral Device Guide</title>

--- a/public/PMD/index.html
+++ b/public/PMD/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -13,15 +15,6 @@
     <link rel="apple-touch-icon" href="/PMD/images/apple-touch-icon.png" />
     <link rel="manifest" href="/PMD/manifest.webmanifest" />
     <title>PREtendingMD — PEM FlowMaster</title>
-    <!-- Google Analytics 4 — shared CloseDose property. Tracks PREtendingMD
-         traffic under the /PMD/ path so it appears alongside closedose.com. -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-      gtag('config', 'G-WYY1QFRPYP');
-    </script>
     <script type="module" crossorigin src="/PMD/assets/index-CvJpLYsP.js"></script>
     <link rel="stylesheet" crossorigin href="/PMD/assets/index-CUlIhhWV.css">
   </head>

--- a/public/about.html
+++ b/public/about.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="CloseDose helps families make confident, safe pediatric dosing decisions — free, ad-free, and reviewed by a practicing pediatric emergency physician." />

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -1,0 +1,42 @@
+/*
+ * CloseDose — site-wide analytics loader (single source of truth).
+ *
+ * Include this on every page, as early in <head> as possible, with:
+ *     <script src="/analytics.js"></script>
+ *
+ * The root-relative "/analytics.js" path means the same tag works from
+ * sub-directories (e.g. /legal/, /PMD/). To change the Google Analytics
+ * property, pause tracking, or add site-wide events, edit THIS file only —
+ * no per-page changes required.
+ */
+(function () {
+  'use strict';
+
+  // Google Analytics 4 measurement ID for the shared CloseDose property.
+  var GA_MEASUREMENT_ID = 'G-WYY1QFRPYP';
+
+  // Guard against double-initialisation (e.g. a page that still carries an
+  // old inline snippet). Without this, GA4 would log duplicate page_views.
+  if (window.__closeDoseAnalyticsLoaded) return;
+  window.__closeDoseAnalyticsLoaded = true;
+
+  // Standard GA4 bootstrap. Defining gtag synchronously here (rather than only
+  // after the async library arrives) guarantees window.gtag exists for the
+  // deferred scripts that depend on it — global.js, the calculator widget, and
+  // the Cappy easter egg all call gtag('event', ...) behind `if (window.gtag)`.
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  window.gtag = gtag;
+
+  gtag('js', new Date());
+  gtag('config', GA_MEASUREMENT_ID);
+
+  // Pull in the gtag.js library asynchronously so it never blocks rendering.
+  // Queued commands above are replayed once it loads.
+  if (!document.querySelector('script[src*="googletagmanager.com/gtag/js"]')) {
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
+    (document.head || document.documentElement).appendChild(s);
+  }
+})();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/donations.html
+++ b/public/donations.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Support CloseDose — a free, ad-free pediatric medication calculator built by a Pediatric Emergency Medicine physician." />

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="How to measure and give liquid medicine to your child — the right syringe, the right markings, and common mistakes to avoid." />

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>CloseDose: Pediatric Medication Calculator</title>
@@ -18,13 +20,6 @@
   <link rel="icon" type="image/png" href="images/LOGO-WC.png">
   <link rel="apple-touch-icon" href="images/LOGO-WC.png">
   <link rel="manifest" href="manifest.json">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'G-WYY1QFRPYP');
-  </script>
   <link rel="stylesheet" href="global.css" />
   <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>

--- a/public/legal/disclaimer.html
+++ b/public/legal/disclaimer.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Medical &amp; Site Disclaimer • CloseDose</title>

--- a/public/legal/dmca.html
+++ b/public/legal/dmca.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>DMCA Policy • CloseDose</title>

--- a/public/legal/linking.html
+++ b/public/legal/linking.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Acceptable Use &amp; Linking • CloseDose</title>

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Privacy Policy • CloseDose</title>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Terms of Use • CloseDose</title>

--- a/public/login.html
+++ b/public/login.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/share/index.html
+++ b/public/share/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>CloseDose – Shared dosing card</title>

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Site-wide analytics (Google Analytics 4). Single source: /analytics.js -->
+  <script src="/analytics.js"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="How to accurately weigh an infant or young child at home using the tared scale method or simple subtraction." />


### PR DESCRIPTION
## Why

Google Analytics 4 (`G-WYY1QFRPYP`) was inline on only **2 of 22 pages** — `index.html` and `PMD/index.html`. Traffic to the dosing guides, medication guides, weighing guide, donations, login/dashboard, legal pages, EnteralID, and the shared-card page was **invisible** in analytics, so "usage over time" data was badly incomplete.

There was also a silent bug: the `tag_visit` / `tag_use` events in `global.js` are gated behind `if (window.gtag)`, but `gtag` only existed on `index.html`. On the other 7 pages that load `global.js`, those events were never firing.

## What changed

- **Add `public/analytics.js`** — a single source of truth for the GA4 loader. It's idempotent (guards against duplicate `page_view` hits), defines `window.gtag` synchronously so deferred scripts and the calculator widget that call `gtag(...)` keep working, then async-loads `gtag.js` so it never blocks rendering.
- **Reference it once per page** via root-relative `<script src="/analytics.js"></script>` in the `<head>` of every content page — the root-relative path works from sub-directories like `/legal/` and `/PMD/`.
- **Remove the redundant inline GA snippets** from `index.html` and `PMD/index.html` to avoid double-counting.

## Coverage

Now tracked (16 pages): `index`, `about`, `dosing-guide`, `medication-guides`, `weighing-guide`, `donations`, `dashboard`, `login`, `EnteralID`, `share/index`, all five `legal/*`, and `PMD/index`.

Deliberately skipped:
- `contact.html` — instant `location.replace` redirect + `noindex`, so a hit would never register.
- `cappy/*` — a separate Firebase/React sub-app that ships its own analytics stack; left untouched to avoid touching its build.

## Net effect

- `page_view` tracking now covers the whole static site → meaningful traffic-over-time and per-page data in GA4.
- The existing `tag_visit` / `tag_use` events now fire wherever `global.js` loads.
- Changing the GA property (or pausing tracking) is now a **one-file edit**.

## Note

This only wires up the tracking *code*. The traffic numbers live in the Google Analytics account behind `G-WYY1QFRPYP` (viewable at [analytics.google.com](https://analytics.google.com)) — that can't be accessed from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122C2j54FjHzea3aLY9Rz3x)_