### PR TITLE
Add feature-usage analytics across the live site

### DIFF
--- a/public/analytics.js
+++ b/public/analytics.js
@@ -39,4 +39,82 @@
     s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
     (document.head || document.documentElement).appendChild(s);
   }
+
+  // ---------------------------------------------------------------------------
+  // Feature-usage tracking
+  // ---------------------------------------------------------------------------
+
+  // Acquisition context, read once from the URL and attached to every event so
+  // usage can be sliced by where a visitor came from — e.g. a printed clinic
+  // handout linking to /?src=qr&id=clinic-poster.
+  var search = new URLSearchParams(window.location.search);
+  var SRC = (search.get('src') || 'na').toLowerCase();
+  var ID = (search.get('id') || 'na').toLowerCase();
+
+  // The one safe way to record a feature-usage event. Never throws and quietly
+  // no-ops if analytics is blocked. Exposed as window.cdTrack so inline page
+  // scripts can report usage the same way, e.g.
+  //   window.cdTrack('shopping_mode_toggle', { state: 'on' });
+  function cdTrack(name, eventParams) {
+    if (!name) return;
+    try {
+      var payload = { src: SRC, id: ID };
+      if (eventParams) {
+        Object.keys(eventParams).forEach(function (key) {
+          payload[key] = eventParams[key];
+        });
+      }
+      gtag('event', name, payload);
+    } catch (_) { /* best-effort only — analytics must never break the page */ }
+  }
+  window.cdTrack = cdTrack;
+
+  // Automatic outbound + contact tracking. External links, mailto: and tel:
+  // clicks are some of the most valuable conversions on the site (donations,
+  // sponsorship email, the Poison Control phone number, Shopping-Mode retailer
+  // links) yet are tedious to tag by hand, so capture them site-wide.
+  function trackAnchor(anchor) {
+    var href = anchor.getAttribute('href') || '';
+    if (!href) return;
+    if (/^mailto:/i.test(href)) {
+      cdTrack('email_click', { to: href.replace(/^mailto:/i, '').split('?')[0] });
+    } else if (/^tel:/i.test(href)) {
+      cdTrack('phone_click', { number: href.replace(/^tel:/i, '') });
+    } else if (/^https?:\/\//i.test(href)) {
+      var host = '';
+      try { host = new URL(href, window.location.href).hostname; } catch (_) { host = ''; }
+      if (host && host !== window.location.hostname) {
+        cdTrack('outbound_click', {
+          domain: host.replace(/^www\./, ''),
+          label: (anchor.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+        });
+      }
+    }
+  }
+
+  // A single delegated listener (capture phase, so it still fires when an inner
+  // handler stops propagation) drives both the declarative data-track events and
+  // the automatic anchor tracking above.
+  document.addEventListener('click', function (event) {
+    var node = event.target;
+    if (!node || typeof node.closest !== 'function') return;
+
+    // Declarative tracking: <button data-track="event_name" data-track-foo="bar">
+    // records cdTrack('event_name', { foo: 'bar' }) with no extra JavaScript.
+    var tracked = node.closest('[data-track]');
+    if (tracked) {
+      var extra = {};
+      var data = tracked.dataset || {};
+      Object.keys(data).forEach(function (key) {
+        if (key.indexOf('track') === 0 && key !== 'track') {
+          var param = key.slice('track'.length);
+          extra[param.charAt(0).toLowerCase() + param.slice(1)] = data[key];
+        }
+      });
+      cdTrack(tracked.getAttribute('data-track'), extra);
+    }
+
+    var anchor = node.closest('a[href]');
+    if (anchor) trackAnchor(anchor);
+  }, true);
 })();

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -250,6 +250,8 @@
               aria-selected="true"
               aria-controls="ibu-children"
               data-conc-target="ibu-children"
+              data-track="concentration_view"
+              data-track-conc="ibu-children"
               type="button"
             >
               Children's
@@ -261,6 +263,8 @@
               aria-selected="false"
               aria-controls="ibu-infant"
               data-conc-target="ibu-infant"
+              data-track="concentration_view"
+              data-track-conc="ibu-infant"
               type="button"
             >
               Infant Drops
@@ -595,6 +599,7 @@
 
       function openShop(query) {
         if (!query) return;
+        if (window.cdTrack) window.cdTrack('shop_product_open', { product: query });
         subEl.textContent = query;
         listEl.innerHTML = '';
         retailers.forEach(function (r) {
@@ -616,7 +621,9 @@
       }
 
       toggle.addEventListener('click', function () {
-        setMode(!document.body.classList.contains('shopping-mode'));
+        var on = !document.body.classList.contains('shopping-mode');
+        setMode(on);
+        if (window.cdTrack) window.cdTrack('shopping_mode_toggle', { state: on ? 'on' : 'off' });
       });
 
       document.addEventListener('click', function (e) {

--- a/public/widget/close-dose-calculator.js
+++ b/public/widget/close-dose-calculator.js
@@ -1688,6 +1688,20 @@
       return () => {};
     }
 
+    // Fire once, on the first interaction with the calculator. Paired with the
+    // existing 'calculate_dose' event this reveals the start->complete funnel:
+    // of the people who touch the calculator, how many finish calculating a dose.
+    let hasEngaged = false;
+    const markEngaged = (method) => {
+      if (hasEngaged) {
+        return;
+      }
+      hasEngaged = true;
+      trackCalculatorEvent('calculator_engaged', { method: method });
+    };
+    const onEngageClick = () => markEngaged('control');
+    const onEngageInput = () => markEngaged('weight');
+
     const shouldAnimateSubmit = () => {
       if (
         !elements ||
@@ -1824,6 +1838,8 @@
     };
 
     elements.form.addEventListener('submit', onSubmit);
+    elements.form.addEventListener('click', onEngageClick);
+    elements.form.addEventListener('input', onEngageInput);
 
     updateForm(elements, strings);
     refreshGuidanceAnimations();
@@ -1841,6 +1857,8 @@
       elements.ageSelect.removeEventListener('change', onAgeSelectChange);
       elements.unitSelect.removeEventListener('change', onUnitSelectChange);
       elements.form.removeEventListener('submit', onSubmit);
+      elements.form.removeEventListener('click', onEngageClick);
+      elements.form.removeEventListener('input', onEngageInput);
       elements.weightInput.removeEventListener('input', onWeightInput);
       elements.weightInput.removeEventListener('change', onWeightInput);
       elements.weightInput.removeEventListener('focus', onWeightFocusChange);


### PR DESCRIPTION
## Why

PR #266 made sure every page records a `page_view`, so you can now see **where** traffic goes. This PR adds **feature-usage** events so you can see **what people actually do** — the difference between "200 people visited the medication guides" and "12 of them turned on Shopping Mode and 4 looked at infant ibuprofen."

> **Stacked on #266.** Base is `claude/affectionate-rubin-9jeu13` so this diff is only the new tracking. GitHub will auto-retarget to `main` once #266 merges. (#266 should merge first — these events use the site-wide `gtag`/`cdTrack` that #266 introduces.)

## What's tracked now

**`analytics.js` — reusable, site-wide**
- **`window.cdTrack(name, params)`** — one safe helper that tags every event with acquisition context (`?src` / `?id`), so any feature can be sliced by where the visitor came from (e.g. a printed clinic handout at `/?src=qr&id=clinic-poster`).
- **Automatic outbound/contact tracking** (one delegated listener):
  - external links → `outbound_click {domain}` — **donations** (Ko-fi, GiveButter), partner links
  - `mailto:` → `email_click` — the **sponsorship** inquiry
  - `tel:` → `phone_click` — the **Poison Control** number
  - covers Shopping-Mode retailer links too — all with **zero per-link tagging**
- **Declarative `data-track="event"`** (+ `data-track-*` params) — instrument any element with a single attribute, no JS.

**Calculator (the core feature)**
- **`calculator_engaged`** on first interaction (once per mount). Paired with the existing **`calculate_dose`**, this gives you the **start → complete funnel**: of everyone who touches the calculator, what fraction finishes a dose? (Big signal for friction/UX.)
- Uses the widget's existing fail-safe tracker, so third-party embeds without GA still no-op cleanly.

**Medication guides**
- **`shopping_mode_toggle {state}`** and **`shop_product_open {product}`** — how often Shopping Mode is used and which products parents look to buy.
- **`concentration_view`** on the ibuprofen tabs — whether parents explore Children's vs Infant Drops.

## Insights this unlocks (in GA4 → Reports → Engagement → Events)

- Calculator completion rate (`calculator_engaged` → `calculate_dose`)
- Most-used age bands / units / result types (already on `calculate_dose`)
- Donation & sponsorship intent (`outbound_click`, `email_click`)
- Poison Control taps (`phone_click`) — a safety signal
- Which medications/formulations parents shop for

## Privacy

No PHI. Events carry only categorical, non-identifying data — age band, unit, formulation, medication/product name — **never a child's weight or any free text**. Consistent with the existing privacy policy's "limited analytics (page views, feature usage)" language.

## Note

`script.js` in the repo contains an older calculator + translation UI, but it isn't referenced by any live page (the homepage uses the `widget/` calculator), so it was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122C2j54FjHzea3aLY9Rz3x)_