### PR TITLE
Disable GA4 Google Signals to stop "analytics.google.com refused to connect"

### DIFF
--- a/pmd/index.html
+++ b/pmd/index.html
@@ -20,7 +20,14 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
-      gtag('config', 'G-WYY1QFRPYP');
+      // Disable Google Signals so GA4 never beacons to analytics.google.com
+      // (the cross-site advertising endpoint that ad/privacy blockers refuse,
+      // showing as "analytics.google.com refused to connect"). All hits stay
+      // on www.google-analytics.com. Mirrors /analytics.js used site-wide.
+      gtag('config', 'G-WYY1QFRPYP', {
+        allow_google_signals: false,
+        allow_ad_personalization_signals: false,
+      });
     </script>
   </head>
   <body>

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -29,7 +29,17 @@
   window.gtag = gtag;
 
   gtag('js', new Date());
-  gtag('config', GA_MEASUREMENT_ID);
+  // Disable Google Signals (and ad-personalization signals). Without this,
+  // GA4 fires a cross-site beacon to https://analytics.google.com/g/collect,
+  // which ad/tracker blockers and browser privacy modes routinely refuse —
+  // surfacing as "analytics.google.com refused to connect". Turning Signals
+  // off keeps every hit on www.google-analytics.com, removes that error, and
+  // keeps usage data out of Google's advertising graph — the right default
+  // for a medication app. Standard page_view / event tracking is unaffected.
+  gtag('config', GA_MEASUREMENT_ID, {
+    allow_google_signals: false,
+    allow_ad_personalization_signals: false,
+  });
 
   // Pull in the gtag.js library asynchronously so it never blocks rendering.
   // Queued commands above are replayed once it loads.


### PR DESCRIPTION
## What & why

Users (and the site owner) were seeing **`analytics.google.com refused to connect`**.

Root cause: nothing in our code talks to `analytics.google.com` — that connection is made by the **GA4 runtime** when **Google Signals** is enabled on the `G-WYY1QFRPYP` property. gtag.js fires a cross-site beacon to `https://analytics.google.com/g/collect`, and ad/tracker blockers, Brave/Firefox/Safari privacy modes, and DNS filters routinely **refuse** it — which is what surfaces as that error.

A CSP allowlist would *not* fix this (client-side blockers ignore CSP). The real fix is to stop making the request at the source.

## Change

Set `allow_google_signals: false` and `allow_ad_personalization_signals: false` on the `gtag('config', ...)` call in both source-of-truth sites:

- `public/analytics.js` — the site-wide single source (the deployed `public/PMD/index.html` also loads `/analytics.js`, so the PMD app is covered too)
- `pmd/index.html` — the PMD dev/source inline snippet, kept in sync

`pmd/src/lib/analytics.ts` only fires events (no `config` call), so it needed no change.

## Effect

- All hits now stay on `www.google-analytics.com` → the `analytics.google.com` beacon (and its "refused to connect") is gone.
- Standard `page_view` and custom event tracking are **unaffected**.
- Usage data stays out of Google's advertising graph — the privacy-correct default for a pediatric medication app.

## Trade-off (easily reverted)

Disabling Google Signals turns off cross-device tracking and the Demographics/Interests reports in GA4. If those are wanted, drop the two flags. (Note: Google Signals must also be **on** in GA4 Admin → Data Settings for those reports, so this is a clean client-side off-switch.)

## Out of scope

The Cappy game uses a separate Firebase Analytics property (`G-8N9NNEDR7E`); its Signals setting lives in the Firebase/GA console and isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDYGfqCoGafVXbwCmZSWKz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDYGfqCoGafVXbwCmZSWKz)_