### PR TITLE
Apply PREtendingMD design system to PMD

### DIFF
--- a/pmd/src/App.tsx
+++ b/pmd/src/App.tsx
@@ -588,7 +588,7 @@ export default function App() {
         batch.set(ref, m);
       }
 
-      // Add Patients
+      // Add patients
       const patientsData = [
         { initials: 'JD', firstName: 'Jordan', lastInitial: 'D', age: '4', room: '12', status: 'Work-up', seenState: 'Seen by Fellow', tasks: { labs: 'pending', imaging: 'ordered', meds: 'off', consult: 'off', poIntake: 'off', painControl: 'off', ambulation: 'off', documents: 'off' } },
         { initials: 'MK', firstName: 'Mia', lastInitial: 'K', age: '12', room: '05', status: 'New', seenState: 'To Be Seen', tasks: { labs: 'off', imaging: 'off', meds: 'off', consult: 'off', poIntake: 'off', painControl: 'off', ambulation: 'off', documents: 'off' } },
@@ -633,12 +633,12 @@ export default function App() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col items-center justify-center gap-5 transition-colors">
+      <div className="pmd pmd-playful-shell min-h-screen flex flex-col items-center justify-center gap-5 transition-colors" data-pmd-theme={document.documentElement.classList.contains('dark') ? 'dark' : 'light'}>
         <img src={BRAND.mascot} alt="PREtendingMD bear mascot" className="w-24 h-24 object-contain animate-bounce drop-shadow-md" />
         <img src={BRAND.wordmark} alt="PREtendingMD" className="h-7 w-auto" />
         <div className="flex items-center gap-2 text-gray-400 dark:text-gray-500">
           <Loader2 size={16} className="animate-spin" />
-          <p className="text-sm font-bold uppercase tracking-widest">Initializing Workflow...</p>
+          <p className="text-sm font-bold uppercase tracking-widest">Initializing workflow...</p>
         </div>
       </div>
     );
@@ -761,14 +761,14 @@ export default function App() {
               <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-800 p-6 transition-colors">
                 <div className="flex items-center justify-between mb-6">
                   <div>
-                    <h2 className="text-xl font-black text-gray-900 dark:text-white tracking-tight">Shift Handoff</h2>
+                    <h2 className="text-xl font-black text-gray-900 dark:text-white tracking-tight">Shift handoff</h2>
                     <p className="text-sm text-gray-400 dark:text-gray-500 font-medium">Review and sign-out active patients</p>
                   </div>
                   <button 
                     onClick={() => window.print()}
                     className="px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-xl text-sm font-bold transition-colors print:hidden"
                   >
-                    Print Handoff
+                    Print handoff
                   </button>
                 </div>
                 
@@ -800,7 +800,7 @@ export default function App() {
                                 <p className="text-sm font-medium text-gray-800 dark:text-gray-200"><span className="text-gray-400 dark:text-gray-500">CC:</span> {patient.chiefComplaint}</p>
                               </div>
                               <div className="flex-1 space-y-2">
-                                <div className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pending Tasks</div>
+                                <div className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pending tasks</div>
                                 <div className="flex flex-wrap gap-2">
                                   {Object.entries(patient.tasks).filter(([_, v]) => v === 'pending').map(([k]) => (
                                     <span key={k} className="px-2 py-1 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-500 rounded-md text-xs font-bold capitalize">

--- a/pmd/src/components/LandingScreen.tsx
+++ b/pmd/src/components/LandingScreen.tsx
@@ -30,7 +30,7 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
       return;
     }
     if (!role) {
-      setError('Please select your role (Attending or Fellow).');
+      setError('Please select your role (attending or fellow).');
       return;
     }
 
@@ -51,15 +51,15 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
   };
 
   return (
-    <div className="min-h-[100dvh] bg-slate-50 dark:bg-slate-950 flex items-center justify-center p-4 transition-colors">
+    <div className="pmd pmd-playful-shell min-h-[100dvh] flex items-center justify-center p-4 transition-colors" data-pmd-theme={document.documentElement.classList.contains('dark') ? 'dark' : 'light'}>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: 'easeOut' }}
-        className="max-w-md w-full bg-white dark:bg-slate-900 rounded-[2.5rem] shadow-2xl border border-slate-100 dark:border-slate-800/85 overflow-hidden transition-colors"
+        className="max-w-md w-full pmd-card-surface rounded-[2.5rem] border overflow-hidden transition-colors"
       >
         {/* Banner/Header — brand-forward hero: oversized sticker bear + rainbow wordmark */}
-        <div className="relative overflow-hidden px-8 pt-10 pb-9 text-center bg-gradient-to-b from-slate-50 via-white to-white dark:from-slate-800/40 dark:via-slate-900 dark:to-slate-900 transition-colors">
+        <div className="relative overflow-hidden px-8 pt-10 pb-9 text-center bg-[linear-gradient(180deg,var(--pmd-sky),var(--pmd-surface))] transition-colors">
           {/* Soft rainbow glow echoes the wordmark and spotlights the bear (replaces the old hard circle) */}
           <div
             aria-hidden="true"
@@ -91,13 +91,13 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
             <img src={BRAND.wordmark} alt="PREtendingMD" className="mx-auto block h-10 w-auto" />
           </h1>
 
-          <p className="relative z-10 mt-3 text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Pediatric Emergency Medicine Co-Pilot</p>
+          <p className="relative z-10 mt-3 text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Pediatric emergency medicine co-pilot</p>
         </div>
 
         {/* Form Body */}
         <div className="p-8 space-y-6">
           <div className="text-center space-y-1">
-            <h2 className="text-lg font-black text-slate-800 dark:text-slate-100 tracking-tight">Introduce Yourself</h2>
+            <h2 className="text-lg font-black text-slate-800 dark:text-slate-100 tracking-tight">Introduce yourself</h2>
             <p className="text-xs text-slate-400 dark:text-slate-500 font-medium">Quick entry for real-time collaboration with your shift partner</p>
           </div>
 
@@ -115,7 +115,7 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
             {/* Name Fields */}
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1">First Name</label>
+                <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1">First name</label>
                 <input
                   type="text"
                   required
@@ -128,7 +128,7 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
               </div>
 
               <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1">Last Name</label>
+                <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1">Last name</label>
                 <input
                   type="text"
                   required
@@ -142,7 +142,7 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
 
             {/* Role Cards (Extremely visual & easy to tap) */}
             <div className="space-y-2">
-              <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1 block">Your Shift Role</label>
+              <label className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest px-1 block">Your shift role</label>
               
               <div className="grid grid-cols-2 gap-4">
                 {/* Attending Card */}
@@ -184,13 +184,13 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
               whileTap={{ scale: 0.98 }}
               type="submit"
               disabled={isSubmitting || loading}
-              className="w-full py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-2xl font-black uppercase tracking-wider text-xs shadow-xl shadow-blue-200 dark:shadow-none flex items-center justify-center gap-2 disabled:opacity-50 transition-all cursor-pointer"
+              className="w-full py-4 pmd-primary-action text-white rounded-2xl font-black uppercase tracking-wider text-xs shadow-xl shadow-blue-200 dark:shadow-none flex items-center justify-center gap-2 disabled:opacity-50 transition-all cursor-pointer"
             >
               {isSubmitting || loading ? (
                 <Loader2 size={16} className="animate-spin" />
               ) : (
                 <>
-                  Enter Shift board
+                  Enter shift board
                   <ArrowRight size={16} />
                 </>
               )}
@@ -201,7 +201,7 @@ export const LandingScreen: React.FC<LandingScreenProps> = ({ onComplete, loadin
         {/* Bottom PII Notice */}
         <div className="p-6 bg-slate-50/50 dark:bg-slate-900/50 border-t border-slate-100 dark:border-slate-800/55 text-center">
           <div className="inline-flex items-center gap-1 text-slate-400 dark:text-slate-500 text-[9px] font-bold uppercase tracking-widest leading-none text-center">
-            <ShieldCheck size={12} className="text-emerald-500 shrink-0" /> Secure Co-Pilot · Limited identifiers only (first name + last initial)
+            <ShieldCheck size={12} className="text-emerald-500 shrink-0" /> Secure co-pilot · limited identifiers only (first name + last initial)
           </div>
         </div>
       </motion.div>

--- a/pmd/src/components/Layout.tsx
+++ b/pmd/src/components/Layout.tsx
@@ -24,6 +24,7 @@ interface LayoutProps {
 import { motion } from 'framer-motion';
 
 export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTab, user, onLogout, onAddTeamMember, activeShiftId, syncState = 'connecting' }) => {
+  const pmdTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
   const tabs = [
     { id: 'board', label: 'Board', icon: <LayoutDashboard size={20} /> },
     { id: 'handoff', label: 'Handoff', icon: <Users size={20} /> },
@@ -87,18 +88,18 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
   };
 
   return (
-    <div className="min-h-[100dvh] bg-gray-50 dark:bg-gray-950 flex flex-col transition-colors overflow-x-hidden">
+    <div className="pmd pmd-app-shell min-h-[100dvh] flex flex-col transition-colors overflow-x-hidden" data-pmd-theme={pmdTheme}>
       {/* Top Navigation - Hidden on Mobile */}
-      <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 sticky top-0 z-50 shadow-sm md:block transition-colors">
+      <header className="pmd-glass-header sticky top-0 z-50 border-b shadow-sm md:block transition-colors">
         <div className="max-w-7xl mx-auto px-4 h-12 md:h-14 flex items-center justify-between">
           <div className="flex items-center gap-2 cursor-pointer" onClick={() => setActiveTab('board')}>
             <img src={BRAND.bearHead} alt="PREtendingMD bear mascot" className="w-7 h-7 md:w-9 md:h-9 object-contain" />
-            <h1 className="text-sm md:text-base font-black text-gray-900 dark:text-white tracking-tight">PRE<span className="text-blue-600 dark:text-blue-400">tendingMD</span></h1>
+            <h1 className="pmd-brand text-sm md:text-base font-black tracking-tight text-[var(--pmd-ink)]">PRE<span className="text-[var(--pmd-family)]">tendingMD</span></h1>
           </div>
 
           <motion.div 
             whileTap={{ scale: 0.95 }}
-            className="flex items-center gap-2 px-4 py-1.5 bg-gray-50 dark:bg-gray-800 rounded-full border border-gray-100 dark:border-gray-700 shadow-xs cursor-pointer select-none transition-transform"
+            className="flex items-center gap-2 px-4 py-1.5 pmd-control-surface rounded-full border shadow-xs cursor-pointer select-none transition-transform"
             onContextMenu={(e) => { e.preventDefault(); handleTimerReset(); }}
             onTouchStart={startHold}
             onTouchEnd={endHold}
@@ -107,7 +108,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
             onMouseLeave={endHold}
             title="Right click or hold to reset"
           >
-            <span className="text-[10px] md:text-xs font-black text-gray-400 uppercase tracking-wider">RTL:</span>
+            <span className="text-[10px] md:text-xs font-black pmd-muted-text uppercase tracking-wider">RTL:</span>
             <span className="text-xs md:text-sm font-black tabular-nums" style={{ color: getTimerColor(rtlSeconds) }}>
               {formatTime(rtlSeconds)}
             </span>
@@ -120,8 +121,8 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
               <motion.button
                 whileTap={{ scale: 0.9 }}
                 onClick={handleShare}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full border border-blue-100 dark:border-blue-800 hover:bg-blue-100 transition-colors"
-                title="Share Session"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--pmd-family-soft)] text-[var(--pmd-family-ink)] rounded-full border border-[var(--pmd-family-line)] hover:bg-[var(--pmd-family-line)] transition-colors"
+                title="Share session"
               >
                 {isCopied ? <Check size={16} /> : <Share2 size={16} />}
                 <span className="text-[10px] font-black uppercase tracking-tighter hidden sm:inline">
@@ -131,10 +132,10 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
             )}
 
             <div 
-              className="flex items-center gap-2 px-2 py-1 md:px-3 md:py-1.5 bg-gray-50 dark:bg-gray-800 rounded-full border border-gray-100 dark:border-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              className="flex items-center gap-2 px-2 py-1 md:px-3 md:py-1.5 pmd-control-surface rounded-full border cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
               onClick={() => setActiveTab('settings')}
             >
-              <div className="w-5 h-5 md:w-6 md:h-6 rounded-full bg-blue-100 dark:bg-blue-900/50 flex items-center justify-center text-blue-600 dark:text-blue-400 overflow-hidden">
+              <div className="w-5 h-5 md:w-6 md:h-6 rounded-full bg-[var(--pmd-family-soft)] flex items-center justify-center text-[var(--pmd-family-ink)] overflow-hidden">
                 {user?.photoURL ? (
                   <img src={user.photoURL} alt="Avatar" className="w-full h-full object-cover" />
                 ) : (
@@ -153,7 +154,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
       </main>
 
       {/* Bottom Navigation (Mobile Friendly) */}
-      <nav className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 px-4 pt-1 pb-[calc(4px+env(safe-area-inset-bottom))] z-30 md:relative md:border-t-0 md:bg-transparent md:max-w-7xl md:mx-auto md:w-full md:px-4 md:py-4">
+      <nav className="pmd-glass-header fixed bottom-0 left-0 right-0 border-t px-4 pt-1 pb-[calc(4px+env(safe-area-inset-bottom))] z-30 md:relative md:border-t-0 md:bg-transparent md:max-w-7xl md:mx-auto md:w-full md:px-4 md:py-4">
         <div className="flex items-center justify-around md:justify-start md:gap-6 max-w-lg mx-auto md:mx-0">
           {tabs.map(tab => (
             <motion.button
@@ -166,7 +167,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
               className={cn(
                 "flex flex-col md:flex-row items-center gap-0.5 md:gap-3 px-4 py-1.5 rounded-2xl transition-all",
                 activeTab === tab.id 
-                  ? "text-blue-600 bg-blue-50 dark:bg-blue-900/30 md:bg-blue-600 md:text-white md:shadow-lg" 
+                  ? "text-[var(--pmd-family-ink)] bg-[var(--pmd-family-soft)] md:pmd-primary-action md:text-white md:shadow-lg" 
                   : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
               )}
             >

--- a/pmd/src/components/PatientBoard.tsx
+++ b/pmd/src/components/PatientBoard.tsx
@@ -320,10 +320,10 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
     <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       {/* Quick Add Modal */}
       {isQuickAddOpen && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
-          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl shadow-2xl w-full max-w-sm p-6 space-y-4 animate-in zoom-in-95 duration-200 transition-colors">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-950/55 backdrop-blur-sm animate-in fade-in duration-200">
+          <div className="pmd-card-surface border rounded-2xl shadow-2xl w-full max-w-sm p-6 space-y-4 animate-in zoom-in-95 duration-200 transition-colors">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-black text-gray-900 dark:text-white tracking-tight">Quick Add Team</h3>
+              <h3 className="text-lg font-black text-gray-900 dark:text-white tracking-tight">Quick add team</h3>
               <button onClick={() => setIsQuickAddOpen(false)} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors">
                 <X size={20} className="text-gray-400 dark:text-gray-500" />
               </button>
@@ -332,21 +332,21 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             <form onSubmit={handleQuickAdd} className="space-y-4">
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">First Name</label>
+                  <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">First name</label>
                   <input 
                     autoFocus
                     required
-                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none transition-colors"
+                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
                     placeholder="First"
                     value={quickAddData.firstName}
                     onChange={(e) => setQuickAddData({ ...quickAddData, firstName: e.target.value })}
                   />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Last Name</label>
+                  <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Last name</label>
                   <input 
                     required
-                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none transition-colors"
+                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
                     placeholder="Last"
                     value={quickAddData.lastName}
                     onChange={(e) => setQuickAddData({ ...quickAddData, lastName: e.target.value })}
@@ -360,7 +360,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                   <input 
                     required
                     maxLength={3}
-                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none uppercase transition-colors"
+                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none uppercase transition-colors"
                     placeholder="JD"
                     value={quickAddData.initials}
                     onChange={(e) => setQuickAddData({ ...quickAddData, initials: e.target.value.toUpperCase() })}
@@ -369,7 +369,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Role</label>
                   <select 
-                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none transition-colors"
+                    className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
                     value={quickAddData.role}
                     onChange={(e) => setQuickAddData({ ...quickAddData, role: e.target.value as any })}
                   >
@@ -385,9 +385,9 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
 
               <button 
                 type="submit"
-                className="w-full py-3 bg-blue-600 text-white rounded-xl font-black uppercase tracking-widest text-xs hover:bg-blue-700 transition-all shadow-lg shadow-blue-200 dark:shadow-none active:scale-95"
+                className="w-full py-3 pmd-primary-action rounded-xl font-black uppercase tracking-widest text-xs transition-all shadow-lg dark:shadow-none active:scale-95"
               >
-                Add Member
+                Add member
               </button>
             </form>
           </div>
@@ -396,7 +396,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
 
       <div className="space-y-4">
         {/* Team Bar - Scrolling with patients */}
-        <div className="sticky top-12 md:top-14 z-50 bg-white/95 dark:bg-gray-950/95 backdrop-blur-md py-2 border-b border-gray-100 dark:border-gray-800 -mx-4 px-4 shadow-sm flex items-center gap-3 transition-colors overflow-y-hidden">
+        <div className="sticky top-12 md:top-14 z-50 pmd-glass-header py-2 border-b -mx-4 px-4 shadow-sm flex items-center gap-3 transition-colors overflow-y-hidden">
           <div className="flex items-center gap-1.5 shrink-0 opacity-60">
             <Users size={14} className="text-gray-400 dark:text-gray-500" />
             <span className="col-header whitespace-nowrap">Team</span>
@@ -412,7 +412,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 {teamWorkload[m.id] > 0 && (
                   <div className="absolute bottom-0.5 left-1/2 -translate-x-1/2 flex flex-wrap justify-center gap-0.5 z-10 w-8 pointer-events-none">
                     {Array.from({ length: Math.min(teamWorkload[m.id], 4) }).map((_, i) => (
-                      <div key={i} className="w-1 h-1 rounded-full bg-blue-500 border border-white dark:border-gray-900 shadow-sm" />
+                      <div key={i} className="w-1 h-1 rounded-full bg-[var(--pmd-family)] border border-white dark:border-gray-900 shadow-sm" />
                     ))}
                     {teamWorkload[m.id] > 4 && (
                       <div className="w-1 h-1 rounded-full bg-blue-600 border border-white dark:border-gray-900 shadow-sm flex items-center justify-center">
@@ -426,8 +426,8 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             <div className="snap-center">
               <button
                 onClick={() => setIsQuickAddOpen(true)}
-                className="w-10 h-10 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-600 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-300 dark:hover:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-all shrink-0"
-                title="Quick Add Team Member"
+                className="w-10 h-10 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-600 hover:text-[var(--pmd-family-ink)] hover:border-[var(--pmd-family-line)] hover:bg-[var(--pmd-family-soft)] transition-all shrink-0"
+                title="Quick add team member"
               >
                 <Plus size={16} />
               </button>
@@ -438,10 +438,10 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
           </div>
         </div>
 
-        {/* Department census + Add Patient — the board's command row.
+        {/* Department census + Add patient — the board's command row.
             Census counts are live and tappable: each filters the board to that
             ED-course phase so the whole department can be triaged at a glance.
-            Add Patient now lives here (not the team bar) as the mainstay action. */}
+            Add patient now lives here (not the team bar) as the mainstay action. */}
         <div className="flex items-center gap-2">
           <div className="flex-1 flex items-center gap-1.5 overflow-x-auto no-scrollbar py-0.5 -my-0.5">
             <span className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl bg-gray-100 dark:bg-slate-900 border border-gray-200/60 dark:border-gray-800">
@@ -474,10 +474,10 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
 
           <button
             onClick={onAddPatient}
-            className="shrink-0 inline-flex items-center gap-1.5 pl-3 pr-3.5 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-black uppercase tracking-wide text-[11px] shadow-md shadow-blue-200/70 dark:shadow-none active:scale-95 transition-all"
+            className="shrink-0 inline-flex items-center gap-1.5 pl-3 pr-3.5 py-2 pmd-primary-action rounded-xl font-black uppercase tracking-wide text-[11px] shadow-md shadow-blue-200/70 dark:shadow-none active:scale-95 transition-all"
             title="Add a new patient to the board"
           >
-            <Plus size={16} /> Add Patient
+            <Plus size={16} /> Add patient
           </button>
         </div>
 
@@ -492,11 +492,11 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             className={cn(
               "flex-1 py-2.5 px-4 rounded-xl text-[10px] font-black uppercase tracking-wider flex items-center justify-center gap-1.5 transition-all outline-none",
               sortBy === 'createdAt' && sortOrder === 'asc'
-                ? "bg-white dark:bg-slate-800 text-blue-600 dark:text-blue-400 shadow-xs"
+                ? "bg-white dark:bg-slate-800 text-[var(--pmd-family-ink)] shadow-xs"
                 : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             )}
           >
-            ⏱️ Next Up Queue
+            Next up queue
           </button>
           <button
             onClick={() => {
@@ -507,11 +507,11 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             className={cn(
               "flex-1 py-2.5 px-4 rounded-xl text-[10px] font-black uppercase tracking-wider flex items-center justify-center gap-1.5 transition-all outline-none",
               sortBy === 'room'
-                ? "bg-white dark:bg-slate-800 text-blue-600 dark:text-blue-400 shadow-xs"
+                ? "bg-white dark:bg-slate-800 text-[var(--pmd-family-ink)] shadow-xs"
                 : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             )}
           >
-            🏥 Room Order
+            Room order
           </button>
         </div>
 
@@ -524,7 +524,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                   <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
                   <input 
                     autoFocus
-                    className="w-full pl-9 pr-8 py-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg text-xs text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none shadow-sm transition-colors font-mono"
+                    className="w-full pl-9 pr-8 py-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg text-xs text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none shadow-sm transition-colors font-mono"
                     placeholder="Search..."
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -539,7 +539,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
               ) : (
                 <button 
                   onClick={() => setIsSearchOpen(true)}
-                  className="col-header opacity-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  className="col-header opacity-100 hover:text-[var(--pmd-family-ink)] transition-colors"
                 >
                   SEARCH
                 </button>
@@ -552,7 +552,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 }}
                 className={cn(
                   "col-header opacity-100 transition-all",
-                  isFilterOpen ? "text-blue-600 dark:text-blue-400 opacity-100" : "hover:text-blue-600 dark:hover:text-blue-400"
+                  isFilterOpen ? "text-[var(--pmd-family-ink)] opacity-100" : "hover:text-[var(--pmd-family-ink)]"
                 )}
               >
                 FILTER
@@ -565,7 +565,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 }}
                 className={cn(
                   "col-header opacity-100 transition-all",
-                  isSortOpen ? "text-blue-600 dark:text-blue-400 opacity-100" : "hover:text-blue-600 dark:hover:text-blue-400"
+                  isSortOpen ? "text-[var(--pmd-family-ink)] opacity-100" : "hover:text-[var(--pmd-family-ink)]"
                 )}
               >
                 SORT
@@ -623,7 +623,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                       value={filterProvider}
                       onChange={(e) => setFilterProvider(e.target.value)}
                     >
-                      <option value="all">All Providers</option>
+                      <option value="all">All providers</option>
                       {teamMembers.map(m => (
                         <option key={m.id} value={m.id}>{m.initials} - {m.lastName}</option>
                       ))}
@@ -637,7 +637,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                       value={filterStatus}
                       onChange={(e) => setFilterStatus(e.target.value)}
                     >
-                      <option value="all">All Status</option>
+                      <option value="all">All status</option>
                       {['New', 'Staff', 'Work-up', 'ED Observation', 'Likely Discharge', 'Likely Admit', 'Discharge', 'Admit'].map(s => (
                         <option key={s} value={s}>{s}</option>
                       ))}
@@ -683,9 +683,9 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                     </div>
                     <button
                       onClick={onAddPatient}
-                      className="inline-flex items-center gap-1.5 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-full text-[11px] font-black uppercase tracking-widest shadow-md shadow-blue-200/70 dark:shadow-none active:scale-95 transition-all"
+                      className="inline-flex items-center gap-1.5 px-5 py-2.5 pmd-primary-action rounded-full text-[11px] font-black uppercase tracking-widest shadow-md shadow-blue-200/70 dark:shadow-none active:scale-95 transition-all"
                     >
-                      <Plus size={16} /> Add Patient
+                      <Plus size={16} /> Add patient
                     </button>
                   </>
                 ) : (
@@ -698,7 +698,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                       onClick={() => { setSearch(''); setFilterProvider('all'); setFilterStatus('all'); setFilterPhase('all'); }}
                       className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full text-[10px] font-black uppercase tracking-widest hover:bg-gray-50 dark:hover:bg-gray-700 transition-all shadow-sm active:scale-95"
                     >
-                      Clear All Filters
+                      Clear all filters
                     </button>
                   </>
                 )}
@@ -709,16 +709,16 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
           <div className="space-y-6">
             <div className="flex items-center justify-between bg-blue-50 dark:bg-blue-900/20 p-3 rounded-xl border border-blue-100 dark:border-blue-800/50 transition-colors">
               <div className="flex items-center gap-2">
-                <Users size={16} className="text-blue-600 dark:text-blue-400" />
+                <Users size={16} className="text-[var(--pmd-family-ink)]" />
                 <span className="text-sm font-bold text-blue-900 dark:text-blue-100">
                   Filtered by: {teamMembers.find(m => m.id === filterProvider)?.lastName || 'Unknown'}
                 </span>
               </div>
               <button 
                 onClick={() => setFilterProvider('all')}
-                className="text-xs font-bold text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 bg-white dark:bg-gray-800 px-3 py-1.5 rounded-lg shadow-sm transition-colors"
+                className="text-xs font-bold text-[var(--pmd-family-ink)] hover:text-blue-800 dark:hover:text-blue-300 bg-white dark:bg-gray-800 px-3 py-1.5 rounded-lg shadow-sm transition-colors"
               >
-                Clear Filter (All Providers)
+                Clear Filter (All providers)
               </button>
             </div>
             
@@ -785,13 +785,13 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
         )}
       </div>
 
-      {/* Floating Add Patient — mobile only. Patients are added constantly in
+      {/* Floating Add patient — mobile only. Patients are added constantly in
           real time, so keep the action within thumb reach while scrolling.
           The inline command-row button covers desktop. */}
       <motion.button
         whileTap={{ scale: 0.9 }}
         onClick={onAddPatient}
-        className="md:hidden fixed right-4 z-40 flex items-center justify-center w-14 h-14 rounded-full bg-blue-600 text-white shadow-xl shadow-blue-500/30 active:bg-blue-700"
+        className="md:hidden fixed right-4 z-40 flex items-center justify-center w-14 h-14 rounded-full pmd-primary-action shadow-xl active:scale-95"
         style={{ bottom: 'calc(4.75rem + env(safe-area-inset-bottom))' }}
         aria-label="Add patient"
         title="Add patient"

--- a/pmd/src/components/TeamSetup.tsx
+++ b/pmd/src/components/TeamSetup.tsx
@@ -53,7 +53,7 @@ export const TeamSetup: React.FC<TeamSetupProps> = ({ teamMembers, onAdd, onRemo
 
       <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-4 gap-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-700 transition-colors">
         <div className="space-y-1">
-          <label className="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase px-1">First Name</label>
+          <label className="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase px-1">First name</label>
           <input 
             className="w-full p-2 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none transition-colors"
             placeholder="John"
@@ -62,7 +62,7 @@ export const TeamSetup: React.FC<TeamSetupProps> = ({ teamMembers, onAdd, onRemo
           />
         </div>
         <div className="space-y-1">
-          <label className="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase px-1">Last Name</label>
+          <label className="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase px-1">Last name</label>
           <input 
             className="w-full p-2 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none transition-colors"
             placeholder="Doe"

--- a/pmd/src/index.css
+++ b/pmd/src/index.css
@@ -1,4 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=DM+Mono:wght@400;500&family=Gochi+Hand&family=Inter:wght@400;500;600;700;800;900&family=Nunito+Sans:wght@600;700;800;900&display=swap');
+@import './pretendingmd.css';
 @import "tailwindcss";
 
 @layer base {
@@ -60,7 +61,7 @@
 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+  --font-mono: "DM Mono", ui-monospace, SFMono-Regular, monospace;
   --font-serif: "Georgia", serif;
 
   /* BUH Primary Palette (Brown University Health / Lifespan inspired) */
@@ -96,5 +97,69 @@
 
   .col-header {
     @apply font-sans not-italic text-[10px] uppercase tracking-widest opacity-50;
+  }
+}
+
+
+@layer utilities {
+  .pmd-app-shell {
+    background:
+      radial-gradient(circle at top left, color-mix(in oklab, var(--pmd-family) 18%, transparent), transparent 34rem),
+      linear-gradient(180deg, var(--pmd-bg), var(--pmd-bg-2));
+    color: var(--pmd-ink);
+    font-family: var(--pmd-font-ui);
+  }
+
+  .pmd-board-panel {
+    background: color-mix(in oklab, var(--pmd-surface) 84%, transparent);
+    border-color: var(--pmd-line);
+    box-shadow: var(--pmd-shadow-card);
+  }
+
+  .pmd-primary-action {
+    background: var(--pmd-fellow-grad);
+    color: var(--pmd-ink-onbrand);
+    box-shadow: 0 14px 30px -16px color-mix(in oklab, var(--pmd-fellow) 70%, transparent);
+  }
+
+  .pmd-primary-action:hover {
+    filter: saturate(1.05) brightness(0.98);
+  }
+}
+
+@layer components {
+  .pmd .pmd-card-surface {
+    background: var(--pmd-surface);
+    border-color: var(--pmd-line);
+    box-shadow: var(--pmd-shadow-card);
+    color: var(--pmd-ink);
+  }
+
+  .pmd .pmd-glass-header {
+    background: var(--pmd-header);
+    border-color: var(--pmd-line);
+    backdrop-filter: blur(16px);
+  }
+
+  .pmd .pmd-muted-text {
+    color: var(--pmd-ink-3);
+  }
+
+  .pmd .pmd-control-surface {
+    background: var(--pmd-surface-2);
+    border-color: var(--pmd-line);
+    color: var(--pmd-ink-2);
+  }
+
+  .pmd .pmd-playful-shell {
+    background:
+      radial-gradient(circle at 20% 0%, color-mix(in oklab, var(--crayon-yellow) 18%, transparent), transparent 22rem),
+      radial-gradient(circle at 80% 8%, color-mix(in oklab, var(--crayon-teal) 20%, transparent), transparent 24rem),
+      linear-gradient(180deg, var(--pmd-cream), var(--pmd-bg));
+  }
+
+  .pmd .pmd-clinical-title {
+    font-family: var(--pmd-font-clinical);
+    letter-spacing: -0.025em;
   }
 }

--- a/pmd/src/pretendingmd.css
+++ b/pmd/src/pretendingmd.css
@@ -1,0 +1,259 @@
+/* =========================================================================
+   PREtendingMD — sub-brand tokens
+   A child of the CloseDose family. The vivid CLINICAL SPECTRUM leads the app;
+   CloseDose teal stays a quiet family thread. Two registers:
+     • CLINICAL  — board, patient cards, workflow. Clean, professional, dense.
+     • PLAYFUL   — launch / login / empty states / settings / footer. Teddy + crayon.
+   The harmonized clinical spectrum is the grown-up sibling of the crayon rainbow
+   in the wordmark — same hues, tuned to one lightness/chroma so they read as a set.
+   Works in warm-dark navy AND soft pediatric-pastel light.
+   All tokens are --pmd-* namespaced; surfaces switch on .pmd[data-pmd-theme].
+   ========================================================================= */
+
+:root {
+  /* ---------------------------------------------------------------------
+     CRAYON RAINBOW — the playful register (sampled from the wordmark)
+     Used in playful shells, empty states, the launch hero, decorative bits.
+     --------------------------------------------------------------------- */
+  --crayon-red:    #e64a44;
+  --crayon-orange: #f18b2b;
+  --crayon-yellow: #f4c430;
+  --crayon-green:  #3aa553;
+  --crayon-teal:   #3ba2c3;
+  --crayon-blue:   #1b69b9;
+  --crayon-indigo: #5b62c4;
+  --crayon-violet: #8769b6;
+
+  /* Teddy / paper tones (for sticker grounds, illustration captions) */
+  --teddy-fur:    #d9a36b;
+  --teddy-fur-dk: #a9743f;
+  --teddy-cream:  #f7efe1;
+  --teddy-nose:   #4a3b34;
+
+  /* ---------------------------------------------------------------------
+     CLINICAL SPECTRUM — the lead system. One tuned family (L~0.63, C high).
+     Each: base vivid fill (mode-independent), -on (text over fill),
+     -ink (text/icon on a light surface), -soft (tint over any surface),
+     -line (hairline over any surface), -grad (signature active gradient).
+     --------------------------------------------------------------------- */
+
+  /* TO BE SEEN · rose — needs a clinician */
+  --pmd-tobeseen:      oklch(0.665 0.205 18);
+  --pmd-tobeseen-ink:  oklch(0.555 0.190 18);
+  --pmd-tobeseen-on:   #ffffff;
+  --pmd-tobeseen-soft: color-mix(in oklab, var(--pmd-tobeseen) 15%, transparent);
+  --pmd-tobeseen-line: color-mix(in oklab, var(--pmd-tobeseen) 42%, transparent);
+  --pmd-tobeseen-grad: linear-gradient(135deg, oklch(0.72 0.19 26), oklch(0.62 0.21 12)); /* @kind color */
+
+  /* WORK-UP · sky — orders in flight */
+  --pmd-workup:        oklch(0.705 0.145 230);
+  --pmd-workup-ink:    oklch(0.560 0.135 232);
+  --pmd-workup-on:     #ffffff;
+  --pmd-workup-soft:   color-mix(in oklab, var(--pmd-workup) 16%, transparent);
+  --pmd-workup-line:   color-mix(in oklab, var(--pmd-workup) 42%, transparent);
+  --pmd-workup-grad:   linear-gradient(135deg, oklch(0.76 0.13 222), oklch(0.66 0.16 238)); /* @kind color */
+
+  /* FELLOW · blue — care phase 1 */
+  --pmd-fellow:        oklch(0.620 0.180 254);
+  --pmd-fellow-ink:    oklch(0.515 0.165 254);
+  --pmd-fellow-on:     #ffffff;
+  --pmd-fellow-soft:   color-mix(in oklab, var(--pmd-fellow) 16%, transparent);
+  --pmd-fellow-line:   color-mix(in oklab, var(--pmd-fellow) 44%, transparent);
+  --pmd-fellow-grad:   linear-gradient(135deg, oklch(0.70 0.16 244), oklch(0.57 0.19 258)); /* @kind color */
+
+  /* STAFFED · indigo — care phase 2 / admit */
+  --pmd-staffed:       oklch(0.590 0.195 276);
+  --pmd-staffed-ink:   oklch(0.500 0.180 276);
+  --pmd-staffed-on:    #ffffff;
+  --pmd-staffed-soft:  color-mix(in oklab, var(--pmd-staffed) 17%, transparent);
+  --pmd-staffed-line:  color-mix(in oklab, var(--pmd-staffed) 44%, transparent);
+  --pmd-staffed-grad:  linear-gradient(135deg, oklch(0.67 0.17 268), oklch(0.55 0.20 280)); /* @kind color */
+
+  /* ATTENDING · violet — care phase 3 */
+  --pmd-attending:      oklch(0.625 0.205 300);
+  --pmd-attending-ink:  oklch(0.520 0.190 300);
+  --pmd-attending-on:   #ffffff;
+  --pmd-attending-soft: color-mix(in oklab, var(--pmd-attending) 17%, transparent);
+  --pmd-attending-line: color-mix(in oklab, var(--pmd-attending) 44%, transparent);
+  --pmd-attending-grad: linear-gradient(135deg, oklch(0.71 0.18 296), oklch(0.58 0.21 306)); /* @kind color */
+
+  /* DISPO · fuchsia — disposition pending */
+  --pmd-dispo:        oklch(0.635 0.225 334);
+  --pmd-dispo-ink:    oklch(0.535 0.205 334);
+  --pmd-dispo-on:     #ffffff;
+  --pmd-dispo-soft:   color-mix(in oklab, var(--pmd-dispo) 16%, transparent);
+  --pmd-dispo-line:   color-mix(in oklab, var(--pmd-dispo) 42%, transparent);
+  --pmd-dispo-grad:   linear-gradient(135deg, oklch(0.71 0.21 340), oklch(0.59 0.23 326)); /* @kind color */
+
+  /* READY · emerald — good to go (rhymes with the family teal) */
+  --pmd-ready:        oklch(0.735 0.165 160);
+  --pmd-ready-ink:    oklch(0.560 0.135 162);
+  --pmd-ready-on:     #06231a;
+  --pmd-ready-soft:   color-mix(in oklab, var(--pmd-ready) 18%, transparent);
+  --pmd-ready-line:   color-mix(in oklab, var(--pmd-ready) 44%, transparent);
+  --pmd-ready-grad:   linear-gradient(135deg, oklch(0.80 0.16 158), oklch(0.69 0.17 166)); /* @kind color */
+
+  /* ---------- Clinical semantics (reuse spectrum hues) ---------- */
+  --pmd-admit:        var(--pmd-staffed);
+  --pmd-admit-grad:   var(--pmd-staffed-grad);
+  --pmd-discharge:    var(--pmd-ready);
+  --pmd-edobs:        var(--pmd-workup);
+
+  /* Flag / barrier states */
+  --pmd-flag:         oklch(0.785 0.155 78);   /* amber — barrier open */
+  --pmd-flag-ink:     oklch(0.580 0.130 70);
+  --pmd-flag-on:      #2c1d02;
+  --pmd-flag-soft:    color-mix(in oklab, var(--pmd-flag) 18%, transparent);
+  --pmd-flag-line:    color-mix(in oklab, var(--pmd-flag) 46%, transparent);
+  --pmd-clear:        var(--pmd-ready);        /* barrier cleared */
+
+  /* Overdue / urgent */
+  --pmd-urgent:       oklch(0.640 0.225 22);
+  --pmd-urgent-soft:  color-mix(in oklab, var(--pmd-urgent) 16%, transparent);
+
+  /* ---------- FAMILY THREAD — CloseDose teal, kept quiet ---------- */
+  --pmd-family:       #18a78d;                 /* CloseDose Teal 500 */
+  --pmd-family-2:     #128873;
+  --pmd-family-ink:   #0e6d5c;
+  --pmd-family-soft:  color-mix(in oklab, var(--pmd-family) 16%, transparent);
+  --pmd-family-line:  color-mix(in oklab, var(--pmd-family) 40%, transparent);
+
+  /* Sex tags (board convention) */
+  --pmd-male:         var(--pmd-fellow);
+  --pmd-female:       var(--pmd-dispo);
+
+  /* ---------------------------------------------------------------------
+     Type — clinical core stays clean; brand display is warm + rounded.
+     --------------------------------------------------------------------- */
+  --pmd-font-brand:    'Baloo 2', 'Nunito Sans', ui-rounded, system-ui, sans-serif;
+  --pmd-font-clinical: 'Nunito Sans', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --pmd-font-ui:       'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --pmd-font-mono:     'DM Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --pmd-font-chalk:    'Gochi Hand', 'Baloo 2', cursive;  /* sparing: launch tagline, empty states */
+
+  /* ---------------------------------------------------------------------
+     Radii — a touch friendlier than CloseDose.
+     --------------------------------------------------------------------- */
+  --pmd-r-chip:   8px;
+  --pmd-r-btn:    11px;
+  --pmd-r-field:  12px;
+  --pmd-r-card:   18px;
+  --pmd-r-panel:  22px;
+  --pmd-r-hero:   28px;
+  --pmd-r-pill:   999px;
+
+  /* ---------- Motion (inherits CloseDose calm) ---------- */
+  --pmd-fast: 160ms; /* @kind other */
+  --pmd-base: 280ms; /* @kind other */
+  --pmd-ease: cubic-bezier(0.2, 0, 0, 1); /* @kind other */
+  --pmd-spring: cubic-bezier(0.34, 1.3, 0.64, 1); /* @kind other */  /* gentle, for playful shells only */
+}
+
+/* =========================================================================
+   LIGHT — soft pediatric pastel (default for .pmd)
+   Warm-cream + pale-blue ground; white cards. Gentle, not clinical-white.
+   ========================================================================= */
+.pmd,
+.pmd[data-pmd-theme="light"] {
+  --pmd-bg:         #eaf1fb;   /* pale blue page wash */
+  --pmd-bg-2:       #e1ebf8;   /* rails / deeper ground */
+  --pmd-cream:      #fcf8f0;   /* warm cream — playful shells */
+  --pmd-sky:        #d4ecfa;   /* pale sky — hero grounds, teddy sticker bg */
+  --pmd-surface:    #ffffff;   /* card */
+  --pmd-surface-2:  #f4f8fd;   /* inset */
+  --pmd-surface-3:  #ffffff;   /* raised */
+  --pmd-header:     rgba(255,255,255,0.82);
+
+  --pmd-line:       rgba(20,40,68,0.10);
+  --pmd-line-soft:  rgba(20,40,68,0.055);
+  --pmd-line-strong:rgba(20,40,68,0.16);
+
+  --pmd-ink:        #14233c;   /* primary */
+  --pmd-ink-2:      #475a76;   /* secondary */
+  --pmd-ink-3:      #74849f;   /* tertiary / captions */
+  --pmd-ink-faint:  #9aa7bf;   /* placeholder / disabled */
+  --pmd-ink-onbrand:#ffffff;
+
+  /* On light, spectrum LABEL text uses the darker -ink variants. */
+  --pmd-shadow-1: 0 1px 2px rgba(20,40,68,0.05), 0 4px 12px -6px rgba(20,40,68,0.10);
+  --pmd-shadow-2: 0 2px 4px rgba(20,40,68,0.06), 0 12px 28px -10px rgba(20,40,68,0.16);
+  --pmd-shadow-3: 0 4px 8px rgba(20,40,68,0.07), 0 24px 48px -14px rgba(20,40,68,0.22);
+  --pmd-shadow-card: var(--pmd-shadow-1);
+  --pmd-active-ring: 0 0 0 1px var(--pmd-line-soft);
+  color-scheme: light;
+}
+
+/* =========================================================================
+   DARK — warm navy board (matches the live screenshot). Never pure black.
+   Vivid spectrum pops; active states glow.
+   ========================================================================= */
+.pmd[data-pmd-theme="dark"] {
+  --pmd-bg:         #070e1c;   /* deep navy page */
+  --pmd-bg-2:       #0a1322;   /* rails */
+  --pmd-cream:      #121a2b;   /* "cream" slot goes warm-navy in dark */
+  --pmd-sky:        #0e1c33;   /* hero ground */
+  --pmd-surface:    #0f1a30;   /* card */
+  --pmd-surface-2:  #16233f;   /* inset */
+  --pmd-surface-3:  #1c2c4c;   /* raised */
+  --pmd-header:     rgba(10,18,34,0.72);
+
+  --pmd-line:       rgba(255,255,255,0.09);
+  --pmd-line-soft:  rgba(255,255,255,0.05);
+  --pmd-line-strong:rgba(255,255,255,0.16);
+
+  --pmd-ink:        #eaf1fb;
+  --pmd-ink-2:      #aab7cf;
+  --pmd-ink-3:      #76849f;
+  --pmd-ink-faint:  #515f7a;
+  --pmd-ink-onbrand:#ffffff;
+
+  /* On dark, spectrum LABEL text uses the bright base variants (override -ink). */
+  --pmd-tobeseen-ink:  var(--pmd-tobeseen);
+  --pmd-workup-ink:    var(--pmd-workup);
+  --pmd-fellow-ink:    var(--pmd-fellow);
+  --pmd-staffed-ink:   color-mix(in oklab, var(--pmd-staffed) 82%, white);
+  --pmd-attending-ink: var(--pmd-attending);
+  --pmd-dispo-ink:     var(--pmd-dispo);
+  --pmd-ready-ink:     var(--pmd-ready);
+  --pmd-flag-ink:      var(--pmd-flag);
+  --pmd-family-ink:    color-mix(in oklab, var(--pmd-family) 70%, white);
+
+  --pmd-shadow-1: 0 1px 2px rgba(0,0,0,0.32), 0 4px 14px -6px rgba(0,0,0,0.46);
+  --pmd-shadow-2: 0 1px 0 rgba(255,255,255,0.04) inset, 0 14px 34px -12px rgba(0,0,0,0.6);
+  --pmd-shadow-3: 0 1px 0 rgba(255,255,255,0.05) inset, 0 26px 56px -16px rgba(0,0,0,0.74);
+  --pmd-shadow-card: var(--pmd-shadow-1);
+  --pmd-active-ring: 0 0 0 1px var(--pmd-line-soft);
+  color-scheme: dark;
+}
+
+/* =========================================================================
+   Base element rules for anything inside .pmd
+   ========================================================================= */
+.pmd {
+  background: var(--pmd-bg);
+  color: var(--pmd-ink);
+  font-family: var(--pmd-font-ui);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.pmd .pmd-brand    { font-family: var(--pmd-font-brand); font-weight: 700; letter-spacing: -0.01em; }
+.pmd .pmd-clinical { font-family: var(--pmd-font-clinical); }
+.pmd .pmd-mono     { font-family: var(--pmd-font-mono); font-feature-settings: "tnum" 1, "zero" 1; }
+.pmd .pmd-chalk    { font-family: var(--pmd-font-chalk); }
+
+/* Eyebrow / section label */
+.pmd .pmd-eyebrow {
+  font-family: var(--pmd-font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--pmd-ink-3);
+}
+
+/* Focus ring — uses whichever spectrum color the element carries, falls to fellow */
+.pmd :focus-visible {
+  outline: 2px solid var(--pmd-fellow);
+  outline-offset: 2px;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## **User description**
### Motivation
- Bring the PREtendingMD sub-brand and CloseDose visual system into the PMD app so the board and landing flows match the design tokens, typography, and color/interaction rules of the design system.
- Scope the sub-brand tokens to the app shell so PREtendingMD-specific surfaces, playful launch shells, and clinical board styling can coexist with existing CloseDose foundations.

### Description
- Added the PREtendingMD token sheet and fonts as `pmd/src/pretendingmd.css` and imported it in `pmd/src/index.css`, including Baloo 2, Nunito Sans, Inter and DM Mono font families and the `--pmd-*` token set.
- Introduced scoped utility/component classes in `pmd/src/index.css` (`.pmd-app-shell`, `.pmd-card-surface`, `.pmd-glass-header`, `.pmd-primary-action`, etc.) and a `.pmd` wrapper driven by `data-pmd-theme` to toggle light/dark surface tokens.
- Applied the theme and tokens across core UI: wrapped the app shell with `.pmd` and `data-pmd-theme`, and updated `pmd/src/components/Layout.tsx`, `pmd/src/components/LandingScreen.tsx`, `pmd/src/components/PatientBoard.tsx`, `pmd/src/components/TeamSetup.tsx`, and `pmd/src/App.tsx` to use the new classes, CloseDose-family teal accents, and adjusted component surface / control styles.
- Small content and UX updates to match voice/visual guidance: sentence-case copy changes, removed/normalized inline emoji from controls, adjusted focus / ring colors to use `--pmd-*` tokens, and updated CTA / modal / navigation styles to use `pmd-primary-action` where applicable.

### Testing
- Ran type-check/lint with `cd pmd && npm run lint`, which completed successfully (no type errors reported by `tsc`).
- Built the production bundle with `cd pmd && npm run build`, which completed successfully (Vite build finished; noted large-chunk advisory only). 
- Attempted a visual verification screenshot via Playwright but it failed because Playwright and a Chromium binary are not installed in the environment, so no automated screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42efce697083299ecd0550b0ca12b0)


___

## **CodeAnt-AI Description**
**Apply the PREtendingMD visual system across the app**

### What Changed
- Updated the landing page, main layout, patient board, team setup, and handoff screen to use the PREtendingMD brand styling, colors, and rounded surfaces
- Added playful launch and loading screens with branded backgrounds, wordmark styling, and updated button treatments
- Changed form labels, headings, and control text to sentence case for a cleaner, more consistent voice
- Swapped the main action buttons, tabs, filters, search, and quick-add controls to the new branded accent styling

### Impact
`✅ Consistent PREtendingMD branding across key screens`
`✅ Clearer, more polished board and form UI`
`✅ Easier-to-scan labels and actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
