### PR TITLE
Refactor PREtendingMD for native-ready layout

### DIFF
--- a/pmd/src/components/Layout.tsx
+++ b/pmd/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { cn, getTimerColor } from '../lib/utils';
 import { TeamMember, Role } from '../types';
 import { BRAND } from '../lib/brand';
 import { SyncStatus, SyncState } from './SyncStatus';
+import { nativeDS } from '../lib/nativeDesignSystem';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -88,10 +89,11 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
   };
 
   return (
-    <div className="pmd pmd-app-shell min-h-[100dvh] flex flex-col transition-colors overflow-x-hidden" data-pmd-theme={pmdTheme}>
+    <div className="pmd pmd-app-shell min-h-[100dvh] flex flex-col transition-colors overflow-x-hidden"
+      style={{ ['--pmd-native-max-width' as any]: `${nativeDS.board.maxContentWidth}px` }} data-pmd-theme={pmdTheme}>
       {/* Top Navigation - Hidden on Mobile */}
       <header className="pmd-glass-header sticky top-0 z-50 border-b shadow-sm md:block transition-colors">
-        <div className="max-w-7xl mx-auto px-4 h-12 md:h-14 flex items-center justify-between">
+        <div className="max-w-[var(--pmd-native-max-width)] mx-auto px-4 h-14 md:h-16 flex items-center justify-between">
           <div className="flex items-center gap-2 cursor-pointer" onClick={() => setActiveTab('board')}>
             <img src={BRAND.bearHead} alt="PREtendingMD bear mascot" className="w-7 h-7 md:w-9 md:h-9 object-contain" />
             <h1 className="pmd-brand text-sm md:text-base font-black tracking-tight text-[var(--pmd-ink)]">PRE<span className="text-[var(--pmd-family)]">tendingMD</span></h1>
@@ -99,7 +101,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
 
           <motion.div 
             whileTap={{ scale: 0.95 }}
-            className="flex items-center gap-2 px-4 py-1.5 pmd-control-surface rounded-full border shadow-xs cursor-pointer select-none transition-transform"
+            className="flex items-center gap-2 px-4 py-2 pmd-control-surface rounded-full min-h-11 border shadow-xs cursor-pointer select-none transition-transform"
             onContextMenu={(e) => { e.preventDefault(); handleTimerReset(); }}
             onTouchStart={startHold}
             onTouchEnd={endHold}
@@ -149,12 +151,12 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
       </header>
 
       {/* Main Content Area */}
-      <main className="flex-1 max-w-7xl mx-auto w-full px-4 pt-0 pb-28 md:pb-4 scroll-touch">
+      <main className="flex-1 max-w-[var(--pmd-native-max-width)] mx-auto w-full px-3 sm:px-4 pt-0 pb-28 md:pb-5 scroll-touch">
         {children}
       </main>
 
       {/* Bottom Navigation (Mobile Friendly) */}
-      <nav className="pmd-glass-header fixed bottom-0 left-0 right-0 border-t px-4 pt-1 pb-[calc(4px+env(safe-area-inset-bottom))] z-30 md:relative md:border-t-0 md:bg-transparent md:max-w-7xl md:mx-auto md:w-full md:px-4 md:py-4">
+      <nav className="pmd-glass-header fixed bottom-0 left-0 right-0 border-t px-4 pt-1 pb-[calc(4px+env(safe-area-inset-bottom))] z-30 md:relative md:border-t-0 md:bg-transparent md:max-w-[var(--pmd-native-max-width)] md:mx-auto md:w-full md:px-4 md:py-4">
         <div className="flex items-center justify-around md:justify-start md:gap-6 max-w-lg mx-auto md:mx-0">
           {tabs.map(tab => (
             <motion.button
@@ -165,7 +167,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeTab, setActiveTa
                 setActiveTab(tab.id);
               }}
               className={cn(
-                "flex flex-col md:flex-row items-center gap-0.5 md:gap-3 px-4 py-1.5 rounded-2xl transition-all",
+                "flex flex-col md:flex-row items-center gap-0.5 md:gap-3 px-4 py-2 rounded-2xl min-h-11 transition-all",
                 activeTab === tab.id 
                   ? "text-[var(--pmd-family-ink)] bg-[var(--pmd-family-soft)] md:pmd-primary-action md:text-white md:shadow-lg" 
                   : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"

--- a/pmd/src/components/PatientBoard.tsx
+++ b/pmd/src/components/PatientBoard.tsx
@@ -11,6 +11,7 @@ import { Search, Filter, SortAsc, SortDesc, Users, Plus, X } from 'lucide-react'
 import { cn, getRoleColor, getPatientPhase, PHASE_TONES, type EdPhaseKey } from '../lib/utils';
 import { DndContext, DragOverlay, useDraggable, useDroppable, DragEndEvent, TouchSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { motion, AnimatePresence } from 'framer-motion';
+import { nativeDS } from '../lib/nativeDesignSystem';
 
 interface PatientBoardProps {
   patients: Patient[];
@@ -52,7 +53,7 @@ const DraggableTeamMember = ({ member, onFilter }: { member: TeamMember, onFilte
         }
       }}
       className={cn(
-        "w-10 h-10 rounded-full border-2 flex flex-col items-center justify-center text-xs font-black cursor-grab active:cursor-grabbing transition-all shadow-sm shrink-0 relative group touch-none",
+        "w-11 h-11 rounded-full border-2 flex flex-col items-center justify-center text-xs font-black cursor-grab active:cursor-grabbing transition-all shadow-sm shrink-0 relative group touch-none",
         getRoleColor(member.role),
         isDragging && "opacity-0 scale-110 shadow-lg"
       )}
@@ -78,10 +79,10 @@ const DraggableTeamMember = ({ member, onFilter }: { member: TeamMember, onFilte
   );
 };
 
-export const PatientBoard: React.FC<PatientBoardProps> = ({ 
-  patients, 
-  teamMembers, 
-  onUpdatePatient, 
+export const PatientBoard: React.FC<PatientBoardProps> = ({
+  patients,
+  teamMembers,
+  onUpdatePatient,
   onDeletePatient,
   onCompletePatient,
   onResetTimer,
@@ -186,7 +187,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
       } else if (sortBy === 'timer') {
         comparison = a.lastAssessmentAt.toMillis() - b.lastAssessmentAt.toMillis();
       }
-      
+
       return sortOrder === 'asc' ? comparison : -comparison;
     });
 
@@ -229,7 +230,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
 
   const groupedPatients = useMemo(() => {
     if (filterProvider === 'all') return { all: filteredAndSortedPatients };
-    
+
     const groups: Record<string, Patient[]> = {};
     filteredAndSortedPatients.forEach(p => {
       if (p.assignedTeam.length === 0) {
@@ -294,7 +295,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
       const memberId = active.data.current.member.id;
       const patientId = over.id as string;
       const patient = patients.find(p => p.id === patientId);
-      
+
       if (patient && !patient.assignedTeam.includes(memberId)) {
         onUpdatePatient(patientId, {
           assignedTeam: [...patient.assignedTeam, memberId]
@@ -333,7 +334,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">First name</label>
-                  <input 
+                  <input
                     autoFocus
                     required
                     className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
@@ -344,7 +345,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 </div>
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Last name</label>
-                  <input 
+                  <input
                     required
                     className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
                     placeholder="Last"
@@ -357,7 +358,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Initials</label>
-                  <input 
+                  <input
                     required
                     maxLength={3}
                     className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none uppercase transition-colors"
@@ -368,7 +369,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 </div>
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-widest px-1">Role</label>
-                  <select 
+                  <select
                     className="w-full p-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none transition-colors"
                     value={quickAddData.role}
                     onChange={(e) => setQuickAddData({ ...quickAddData, role: e.target.value as any })}
@@ -383,7 +384,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 </div>
               </div>
 
-              <button 
+              <button
                 type="submit"
                 className="w-full py-3 pmd-primary-action rounded-xl font-black uppercase tracking-widest text-xs transition-all shadow-lg dark:shadow-none active:scale-95"
               >
@@ -394,9 +395,10 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
         </div>
       )}
 
-      <div className="space-y-4">
+      <div className="space-y-3 sm:space-y-4 pmd-native-board"
+        style={{ ['--pmd-card-gap' as any]: `${nativeDS.board.cardGap}px`, ['--pmd-card-min' as any]: `${nativeDS.board.desktopCardMinWidth}px` }}>
         {/* Team Bar - Scrolling with patients */}
-        <div className="sticky top-12 md:top-14 z-50 pmd-glass-header py-2 border-b -mx-4 px-4 shadow-sm flex items-center gap-3 transition-colors overflow-y-hidden">
+        <div className="sticky top-14 md:top-16 z-50 pmd-glass-header py-2 border-b -mx-4 px-4 shadow-sm flex items-center gap-3 transition-colors overflow-y-hidden">
           <div className="flex items-center gap-1.5 shrink-0 opacity-60">
             <Users size={14} className="text-gray-400 dark:text-gray-500" />
             <span className="col-header whitespace-nowrap">Team</span>
@@ -405,9 +407,9 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
           <div className="flex-1 flex items-center gap-2 overflow-x-auto no-scrollbar py-1 scroll-touch snap-x-mandatory">
             {teamMembers.map(m => (
               <div key={m.id} className="snap-center relative">
-                <DraggableTeamMember 
-                  member={m} 
-                  onFilter={(id) => setFilterProvider(id === filterProvider ? 'all' : id)} 
+                <DraggableTeamMember
+                  member={m}
+                  onFilter={(id) => setFilterProvider(id === filterProvider ? 'all' : id)}
                 />
                 {teamWorkload[m.id] > 0 && (
                   <div className="absolute bottom-0.5 left-1/2 -translate-x-1/2 flex flex-wrap justify-center gap-0.5 z-10 w-8 pointer-events-none">
@@ -426,7 +428,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             <div className="snap-center">
               <button
                 onClick={() => setIsQuickAddOpen(true)}
-                className="w-10 h-10 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-600 hover:text-[var(--pmd-family-ink)] hover:border-[var(--pmd-family-line)] hover:bg-[var(--pmd-family-soft)] transition-all shrink-0"
+                className="w-11 h-11 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-600 hover:text-[var(--pmd-family-ink)] hover:border-[var(--pmd-family-line)] hover:bg-[var(--pmd-family-soft)] transition-all shrink-0"
                 title="Quick add team member"
               >
                 <Plus size={16} />
@@ -442,7 +444,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             Census counts are live and tappable: each filters the board to that
             ED-course phase so the whole department can be triaged at a glance.
             Add patient now lives here (not the team bar) as the mainstay action. */}
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
           <div className="flex-1 flex items-center gap-1.5 overflow-x-auto no-scrollbar py-0.5 -my-0.5">
             <span className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl bg-gray-100 dark:bg-slate-900 border border-gray-200/60 dark:border-gray-800">
               <span className="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-gray-500">Census</span>
@@ -522,14 +524,14 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
               {isSearchOpen ? (
                 <div className="relative animate-in slide-in-from-left-2 duration-200 min-w-[200px]">
                   <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-                  <input 
+                  <input
                     autoFocus
                     className="w-full pl-9 pr-8 py-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg text-xs text-gray-900 dark:text-white focus:ring-2 focus:ring-[var(--pmd-family)] outline-none shadow-sm transition-colors font-mono"
                     placeholder="Search..."
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                   />
-                  <button 
+                  <button
                     onClick={() => { setSearch(''); setIsSearchOpen(false); }}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                   >
@@ -537,15 +539,15 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                   </button>
                 </div>
               ) : (
-                <button 
+                <button
                   onClick={() => setIsSearchOpen(true)}
                   className="col-header opacity-100 hover:text-[var(--pmd-family-ink)] transition-colors"
                 >
                   SEARCH
                 </button>
               )}
-              
-              <button 
+
+              <button
                 onClick={() => {
                   setIsFilterOpen(!isFilterOpen);
                   setIsSortOpen(false);
@@ -558,7 +560,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 FILTER
               </button>
 
-              <button 
+              <button
                 onClick={() => {
                   setIsSortOpen(!isSortOpen);
                   setIsFilterOpen(false);
@@ -571,13 +573,13 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 SORT
               </button>
             </div>
-            
+
             <SyncStatus state={syncState} variant="dot" />
           </div>
 
           <AnimatePresence>
             {isSortOpen && (
-              <motion.div 
+              <motion.div
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}
@@ -586,7 +588,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 <div className="flex flex-wrap items-center gap-2 p-3 glass rounded-2xl shadow-sm transition-colors mb-2">
                   <div className="flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg px-2 py-1 transition-colors">
                     <SortAsc size={14} className="text-gray-400 dark:text-gray-500" />
-                    <select 
+                    <select
                       className="text-xs font-bold text-gray-600 dark:text-gray-300 bg-transparent outline-none font-mono"
                       value={sortBy}
                       onChange={(e) => setSortBy(e.target.value as any)}
@@ -597,7 +599,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                       <option value="age">Age</option>
                       <option value="timer">Timer</option>
                     </select>
-                    <button 
+                    <button
                       onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
                       className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded text-gray-400 dark:text-gray-500 transition-colors"
                     >
@@ -609,7 +611,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
             )}
 
             {isFilterOpen && (
-              <motion.div 
+              <motion.div
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}
@@ -618,7 +620,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                 <div className="flex flex-wrap items-center gap-2 p-3 glass rounded-2xl shadow-sm transition-colors mb-2">
                   <div className="flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg px-2 py-1 transition-colors">
                     <Users size={14} className="text-gray-400 dark:text-gray-500" />
-                    <select 
+                    <select
                       className="text-xs font-bold text-gray-600 dark:text-gray-300 bg-transparent outline-none max-w-[100px]"
                       value={filterProvider}
                       onChange={(e) => setFilterProvider(e.target.value)}
@@ -632,7 +634,7 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
 
                   <div className="flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg px-2 py-1 transition-colors">
                     <Filter size={14} className="text-gray-400 dark:text-gray-500" />
-                    <select 
+                    <select
                       className="text-xs font-bold text-gray-600 dark:text-gray-300 bg-transparent outline-none max-w-[100px]"
                       value={filterStatus}
                       onChange={(e) => setFilterStatus(e.target.value)}
@@ -652,8 +654,8 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
         {/* Patient List */}
         {filterProvider === 'all' ? (
           <div className={cn(
-            "grid gap-2", 
-            twoColumnMode ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" : "grid-cols-1"
+            "grid gap-[var(--pmd-card-gap)]",
+            twoColumnMode ? "grid-cols-1 md:grid-cols-[repeat(auto-fit,minmax(var(--pmd-card-min),1fr))]" : "grid-cols-1 max-w-[720px]"
           )}>
             {filteredAndSortedPatients.map(patient => (
               <PatientCard
@@ -714,21 +716,21 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                   Filtered by: {teamMembers.find(m => m.id === filterProvider)?.lastName || 'Unknown'}
                 </span>
               </div>
-              <button 
+              <button
                 onClick={() => setFilterProvider('all')}
                 className="text-xs font-bold text-[var(--pmd-family-ink)] hover:text-blue-800 dark:hover:text-blue-300 bg-white dark:bg-gray-800 px-3 py-1.5 rounded-lg shadow-sm transition-colors"
               >
                 Clear Filter (All providers)
               </button>
             </div>
-            
+
             {Object.entries(groupedPatients).filter(([groupId]) => groupId === filterProvider).map(([groupId, groupPatients]) => {
               const provider = teamMembers.find(m => m.id === groupId);
               const isCollapsed = collapsedGroups[groupId];
-              
+
               return (
                 <div key={groupId} className="space-y-2">
-                  <button 
+                  <button
                     onClick={() => toggleGroup(groupId)}
                     className="w-full flex items-center justify-between p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
                   >
@@ -750,11 +752,11 @@ export const PatientBoard: React.FC<PatientBoardProps> = ({
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 dark:text-gray-500"><path d="m18 15-6-6-6 6"/></svg>
                     </div>
                   </button>
-                  
+
                   {!isCollapsed && (
                     <div className={cn(
-                      "grid gap-2 pl-2 md:pl-4 border-l-2 border-gray-100 dark:border-gray-800 transition-colors", 
-                      twoColumnMode ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" : "grid-cols-1"
+                      "grid gap-[var(--pmd-card-gap)] pl-2 md:pl-4 border-l-2 border-gray-100 dark:border-gray-800 transition-colors",
+                      twoColumnMode ? "grid-cols-1 md:grid-cols-[repeat(auto-fit,minmax(var(--pmd-card-min),1fr))]" : "grid-cols-1 max-w-[720px]"
                     )}>
                       {groupPatients.map(patient => (
                         <PatientCard

--- a/pmd/src/components/PatientCard.tsx
+++ b/pmd/src/components/PatientCard.tsx
@@ -308,7 +308,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
           aria-label={`${s.sub}${s.done ? ' — done, tap to undo' : ' — tap to mark done'}`}
           title={s.sub}
           className={cn(
-            "flex items-center gap-1 px-2 py-1.5 text-[10px] font-black uppercase tracking-wide transition-colors active:scale-95",
+            "flex items-center gap-1 px-2.5 py-2 text-[10px] min-h-11 font-black uppercase tracking-wide transition-colors active:scale-95",
             i > 0 && "border-l border-slate-200 dark:border-slate-700",
             s.done
               ? cn(TONES[s.tone].bar, "text-white")
@@ -340,7 +340,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
             aria-label={`Disposition ${d.label}${active ? ' — selected, tap to clear' : ''}`}
             title={d.label}
             className={cn(
-              "flex items-center gap-1 px-2 py-1.5 text-[10px] font-black uppercase tracking-wide transition-colors active:scale-95",
+              "flex items-center gap-1 px-2.5 py-2 text-[10px] min-h-11 font-black uppercase tracking-wide transition-colors active:scale-95",
               i > 0 && "border-l border-slate-200 dark:border-slate-700",
               active
                 ? cn(TONES[d.tone].bar, "text-white")
@@ -453,7 +453,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
         // `@container` lets the card respond to its OWN width — so the same
         // component adapts whether it's full-width on a phone or a narrow tile
         // in the desktop grid hub.
-        "@container relative rounded-3xl border bg-white dark:bg-slate-900 shadow-sm overflow-hidden transition-all duration-300",
+        "@container relative rounded-[var(--pmd-r-card)] border bg-white dark:bg-slate-900 shadow-sm overflow-hidden transition-all duration-300 pmd-native-card",
         patient.isCompleted && "opacity-60",
         isGoodToGo
           ? cn("border-emerald-300 dark:border-emerald-800/70 ring-2", tone.ring)
@@ -476,7 +476,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
             <button
               onClick={() => setExpanded(true)}
               aria-label="Expand patient card"
-              className="shrink-0 w-14 h-14 rounded-2xl bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center"
+              className="shrink-0 w-16 h-16 rounded-2xl bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center"
             >
               <span className="block text-[8px] font-black uppercase text-slate-400 dark:text-slate-500 leading-none">Room</span>
               <span className="block font-black text-xl leading-tight text-slate-900 dark:text-white uppercase truncate max-w-[3rem]">{patient.room || '—'}</span>
@@ -519,7 +519,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
                 <button
                   onClick={(e) => { e.stopPropagation(); onUpdate(patient.id, { isPinned: !patient.isPinned }); }}
                   className={cn(
-                    "w-8 h-8 rounded-full grid place-items-center transition-all",
+                    "w-11 h-11 rounded-full grid place-items-center transition-all",
                     patient.isPinned ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" : "text-slate-300 hover:text-slate-500 dark:text-slate-600 dark:hover:text-slate-400"
                   )}
                   aria-label={patient.isPinned ? 'Unpin patient' : 'Pin patient'}
@@ -528,7 +528,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
                 </button>
                 <button
                   onClick={() => setExpanded(true)}
-                  className="w-8 h-8 rounded-full grid place-items-center bg-slate-100 text-slate-400 hover:text-slate-600 dark:bg-slate-800 dark:text-slate-300 transition-colors"
+                  className="w-11 h-11 rounded-full grid place-items-center bg-slate-100 text-slate-400 hover:text-slate-600 dark:bg-slate-800 dark:text-slate-300 transition-colors"
                   aria-label="Expand"
                 >
                   <ChevronDown size={16} />
@@ -539,7 +539,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
 
           {/* Quick-advance action bar — tap to move the patient through their
               ED course (care phase + disposition) without expanding. */}
-          <div className="flex flex-wrap items-center gap-1.5 pl-4 pr-3 pb-3 pt-0.5">
+          <div className="flex flex-wrap items-center gap-2 pl-4 pr-3 pb-3 pt-0.5">
             <span className="text-[8px] font-black uppercase tracking-widest text-slate-300 dark:text-slate-600 self-center mr-0.5">Advance</span>
             {quickStepper}
             {quickDispo}
@@ -557,7 +557,7 @@ export const PatientCard: React.FC<PatientCardProps> = ({
             transition={{ duration: 0.25, ease: 'easeOut' }}
             className="overflow-hidden"
           >
-            <div className="max-h-[80dvh] overflow-y-auto scroll-touch">
+            <div className="max-h-[82dvh] overflow-y-auto scroll-touch">
               <div className="p-3 @md:p-4 space-y-3.5">
 
                 {/* Top region: clicking any non-control space above the free-text box collapses the card. */}

--- a/pmd/src/lib/nativeDesignSystem.ts
+++ b/pmd/src/lib/nativeDesignSystem.ts
@@ -1,0 +1,43 @@
+/**
+ * React Native-ready PREtendingMD design primitives.
+ *
+ * Keep these values as numbers or plain strings so they can move directly into
+ * a future React Native StyleSheet without translating Tailwind classes. The
+ * web app consumes the same constants for spacing, touch targets and layout
+ * breakpoints, making this Vite build the compatibility layer for iOS work.
+ */
+export const nativeDS = {
+  spacing: {
+    xxs: 4,
+    xs: 8,
+    sm: 12,
+    md: 16,
+    lg: 20,
+    xl: 24,
+    xxl: 32,
+  },
+  radius: {
+    chip: 10,
+    control: 14,
+    card: 24,
+    sheet: 28,
+    round: 999,
+  },
+  touch: {
+    minimum: 44,
+    comfortable: 52,
+    primary: 56,
+  },
+  board: {
+    maxContentWidth: 1180,
+    singleColumnWidth: 720,
+    cardGap: 12,
+    desktopCardMinWidth: 320,
+  },
+  elevation: {
+    card: '0 10px 30px -22px rgba(20,40,68,0.55)',
+    floating: '0 20px 45px -24px rgba(20,40,68,0.7)',
+  },
+} as const;
+
+export type NativeDesignSystem = typeof nativeDS;

--- a/pmd/src/pretendingmd.css
+++ b/pmd/src/pretendingmd.css
@@ -257,3 +257,37 @@
   outline-offset: 2px;
   border-radius: 6px;
 }
+
+/* React Native migration bridge: numeric primitives mirror nativeDesignSystem.ts. */
+.pmd {
+  --pmd-native-touch-min: 44px;
+  --pmd-native-touch-comfortable: 52px;
+  --pmd-native-content-max: 1180px;
+  --pmd-native-card-min: 320px;
+}
+
+.pmd button,
+.pmd input,
+.pmd select,
+.pmd textarea {
+  touch-action: manipulation;
+}
+
+.pmd button,
+.pmd [role="button"] {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.pmd-native-card {
+  box-shadow: var(--pmd-shadow-card), 0 10px 30px -22px rgba(20,40,68,0.55);
+}
+
+@media (max-width: 640px) {
+  .pmd-native-board {
+    margin-inline: -0.25rem;
+  }
+
+  .pmd-native-card {
+    border-radius: 22px;
+  }
+}


### PR DESCRIPTION
## **User description**
### Motivation
- Prepare the PREtendingMD app for an eventual React Native (iOS) migration by surfacing numeric design tokens and making layout/touch targets app-friendly.
- Unify spacing, radii, touch sizes and board sizing into a single native-oriented design primitive so the same values can be reused in a future React Native `StyleSheet`.
- Improve mobile ergonomics and visual rhythm of the board and patient cards so the web UI matches expected app sizing and touch affordances.

### Description
- Added `pmd/src/lib/nativeDesignSystem.ts` which exports `nativeDS` (spacing, radius, touch, board, elevation tokens) and `NativeDesignSystem` type for reuse. 
- Updated the app shell to consume `nativeDS.board.maxContentWidth` and increase header/bottom nav and control tap heights to more comfortable values for touch (`Layout.tsx`).
- Refactored the patient board to use token-backed card gaps/min widths and adaptive grid rules and made the team bar and command rows more thumb-friendly (`PatientBoard.tsx`).
- Increased quick-action control sizes, card rounding/elevation hooks, and expanded card max-height for mobile use, and added a small JS/CSS compatibility layer so the web build reads the same numeric primitives (`PatientCard.tsx`, `pretendingmd.css`).

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and it completed successfully. 
- Ran `npm run build` (Vite) and the production build completed successfully though Vite emitted the existing large-chunk size warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43018ad62883299885794595a3ec01)


___

## **CodeAnt-AI Description**
**Make PREtendingMD more touch-friendly and app-like on mobile**

### What Changed
- Increased tap targets and spacing across the main shell, board controls, team avatars, and patient card actions so the app is easier to use by touch.
- Tightened the board layout to a consistent max width and adjusted patient grid spacing so cards and controls stay readable on smaller screens.
- Made patient cards and quick action controls larger, with a bit more vertical room in the expanded view for easier scanning and interaction.

### Impact
`✅ Easier tap targets on phones`
`✅ Fewer mis-taps on patient actions`
`✅ Cleaner board layout on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
