### PR TITLE
Scope task cue inference to matched context

### DIFF
--- a/pmd/src/components/PatientCard.tsx
+++ b/pmd/src/components/PatientCard.tsx
@@ -380,13 +380,23 @@ export const PatientCard: React.FC<PatientCardProps> = ({
   };
 
   const inferTaskState = (text: string, patterns: RegExp[]): TaskState | undefined => {
-    const hasMention = patterns.some((pattern) => pattern.test(text));
-    if (!hasMention) return undefined;
-
     const completionPattern = /\b(done|completed|complete|resulted|result|negative|normal|clear|given|gave|received|s\/p|after|finished)\b/;
     const pendingPattern = /\b(plan|ordered?|pending|await(?:ing)?|follow[- ]?up|f\/u|send(?:ing)?|obtain|check|collect|swab|culture|cx|consult|page|trial|po challenge|needs?|give|start)\b/;
 
-    if (completionPattern.test(text) && !pendingPattern.test(text)) return 'complete';
+    // Evaluate cues only within the same local phrase/clause as the task
+    // mention. This keeps unrelated work (for example, "labs pending") from
+    // forcing another mentioned task (for example, "meds given") to pending.
+    const taskContexts = text
+      .split(/(?:[.;!?\n]+|,|\s+-\s+|\s+\b(?:and|but|then)\b\s+)/)
+      .map((context) => context.trim())
+      .filter((context) => context.length > 0 && patterns.some((pattern) => pattern.test(context)));
+
+    if (taskContexts.length === 0) return undefined;
+
+    const hasPendingContext = taskContexts.some((context) => pendingPattern.test(context));
+    const hasCompleteContext = taskContexts.some((context) => completionPattern.test(context));
+
+    if (hasCompleteContext && !hasPendingContext) return 'complete';
     return 'pending';
   };
 


### PR DESCRIPTION
## **User description**
### Motivation
- Fix incorrect `inferTaskState` logic that evaluated completion and pending cues against the entire note, which caused unrelated pending phrases (e.g., "labs pending") to force other tasks (e.g., "meds given") into a pending state.

### Description
- Update `inferTaskState` in `pmd/src/components/PatientCard.tsx` to split the note into local contexts by sentence/phrase/clause boundaries, keep only contexts that mention the task, and evaluate `completionPattern` and `pendingPattern` within those contexts, returning `undefined` when no local mention exists.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and `npm run build` (`vite build`), both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43033fffe88329b6733cebda688799)


___

## **CodeAnt-AI Description**
**Scope task status cues to the matching task text**

### What Changed
- Task status is now inferred only from the sentence or phrase that mentions that task.
- Unrelated words elsewhere in the note no longer force a task into pending or complete.
- If a task is not mentioned in any local context, no status is inferred.

### Impact
`✅ Fewer incorrect task status updates`
`✅ More accurate patient note summaries`
`✅ Clearer task tracking from mixed notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
