### PR TITLE
Preserve adjacent cue-only clauses when inferring task state

### DIFF
--- a/pmd/src/components/PatientCard.tsx
+++ b/pmd/src/components/PatientCard.tsx
@@ -379,25 +379,40 @@ export const PatientCard: React.FC<PatientCardProps> = ({
     setExpanded(false);
   };
 
-  const inferTaskState = (text: string, patterns: RegExp[]): TaskState | undefined => {
+  const inferTaskState = (text: string, patterns: RegExp[], allPatterns: RegExp[]): TaskState | undefined => {
     const completionPattern = /\b(done|completed|complete|resulted|result|negative|normal|clear|given|gave|received|s\/p|after|finished)\b/;
     const pendingPattern = /\b(plan|ordered?|pending|await(?:ing)?|follow[- ]?up|f\/u|send(?:ing)?|obtain|check|collect|swab|culture|cx|consult|page|trial|po challenge|needs?|give|start)\b/;
+    const cuePattern = new RegExp(`${completionPattern.source}|${pendingPattern.source}`);
 
-    // Evaluate cues only within the same local phrase/clause as the task
-    // mention. This keeps unrelated work (for example, "labs pending") from
-    // forcing another mentioned task (for example, "meds given") to pending.
-    const taskContexts = text
+    // Evaluate cues in the task clause plus adjacent cue-only clauses. This
+    // captures shorthand like "CT, negative" without letting another task's
+    // cues (for example, "labs pending") change this task.
+    const clauses = text
       .split(/(?:[.;!?\n]+|,|\s+-\s+|\s+\b(?:and|but|then)\b\s+)/)
       .map((context) => context.trim())
-      .filter((context) => context.length > 0 && patterns.some((pattern) => pattern.test(context)));
+      .filter((context) => context.length > 0);
+    const taskContexts = new Map<number, string>();
 
-    if (taskContexts.length === 0) return undefined;
+    clauses.forEach((context, index) => {
+      if (!patterns.some((pattern) => pattern.test(context))) return;
+      taskContexts.set(index, context);
+      [index - 1, index + 1].forEach((adjacentIndex) => {
+        const adjacent = clauses[adjacentIndex];
+        if (adjacent && cuePattern.test(adjacent) && !allPatterns.some((pattern) => pattern.test(adjacent))) {
+          taskContexts.set(adjacentIndex, adjacent);
+        }
+      });
+    });
 
-    const hasPendingContext = taskContexts.some((context) => pendingPattern.test(context));
-    const hasCompleteContext = taskContexts.some((context) => completionPattern.test(context));
+    if (taskContexts.size === 0) return undefined;
 
-    if (hasCompleteContext && !hasPendingContext) return 'complete';
-    return 'pending';
+    return [...taskContexts]
+      .sort(([a], [b]) => a - b)
+      .reduce<TaskState>((state, [, context]) => {
+        if (pendingPattern.test(context)) return 'pending';
+        if (completionPattern.test(context)) return 'complete';
+        return state;
+      }, 'pending');
   };
 
   const getSmartTextUpdates = (rawText: string): Partial<Patient> => {
@@ -415,8 +430,10 @@ export const PatientCard: React.FC<PatientCardProps> = ({
       ['documents', [/\b(discharge instructions?|paperwork|school note|work note|chart(?:ing)?|documentation|note)\b/]],
     ];
 
+    const allTaskPatterns = inferredTasks.flatMap(([, patterns]) => patterns);
+
     inferredTasks.forEach(([key, patterns]) => {
-      const next = inferTaskState(text, patterns);
+      const next = inferTaskState(text, patterns, allTaskPatterns);
       if (next && (patient.tasks[key] === 'off' || patient.tasks[key] === 'none')) {
         taskUpdates[key] = next;
       }


### PR DESCRIPTION
## **User description**
### Motivation
- The flagged issue is valid: clause filtering previously dropped adjacent cue-only phrases (e.g., "CT, negative"), causing completed work to be misclassified as pending.
- The inference needs to include cue-only fragments adjacent to the matched task clause while ignoring adjacent clauses that mention other tasks. 
- I attempted to fetch other PR comments but the GitHub CLI was not available in this environment; tell me if you want me to validate and address the remaining comments.

### Description
- Changed `inferTaskState` signature to `inferTaskState(text: string, patterns: RegExp[], allPatterns: RegExp[])` to give the function visibility of other task patterns. 
- Split note text into clause tokens, locate the clause(s) that match the task, and include adjacent cue-only clauses via a new `cuePattern` while excluding adjacent clauses that contain a different task pattern. 
- Evaluate matched and adjacent clauses in left-to-right order and reduce them so later completion cues (e.g., `resulted`, `negative`) can override earlier pending cues (e.g., `ordered`, `pending`). 
- Pass `allTaskPatterns` (derived from `inferredTasks`) into each `inferTaskState` call in `getSmartTextUpdates`.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and it succeeded. 
- Ran `npm run build` (`vite build`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4306ce438c8329bd295c005b11e983)


___

## **CodeAnt-AI Description**
**Preserve completion cues next to a task without mixing in other tasks**

### What Changed
- Task state now considers nearby cue-only phrases like “negative” or “given” when they sit next to the task being mentioned, so shorthand notes such as “CT, negative” are classified correctly.
- Cues from nearby text only affect the current task if they do not belong to a different task mention, which avoids flipping one task based on another task’s note.
- When both pending and completion cues are present, the later cue in the note now decides the final task state.

### Impact
`✅ Fewer misclassified task statuses`
`✅ Correct handling of shorthand note entries`
`✅ More reliable patient task updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
