### PR TITLE
Make Jungle Run turns continuous

### DIFF
--- a/public/Jungle Run/Cappy3D.html
+++ b/public/Jungle Run/Cappy3D.html
@@ -180,11 +180,9 @@
     </section>
 
     <div id="pow-word" class="pow-word hidden" aria-hidden="true"></div>
-    <div id="panel-wipe" class="panel-wipe" aria-hidden="true"></div>
-
     <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
   </main>
 
-  <script src="cappy-3d.js"></script>
+  <script src="cappy-3d.js?v=20260718-continuous-turns"></script>
 </body>
 </html>

--- a/public/Jungle Run/cappy-3d.css
+++ b/public/Jungle Run/cappy-3d.css
@@ -99,8 +99,7 @@ a:focus-visible {
 }
 
 .comic-grain,
-.speed-lines,
-.panel-wipe {
+.speed-lines {
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -1206,28 +1205,6 @@ h1 em {
   30% { transform: translate(-50%, -50%) scale(1) rotate(-1.5deg); }
   78% { opacity: 1; }
   100% { opacity: 0; transform: translate(-50%, -56%) scale(.92) rotate(-1.5deg); }
-}
-
-.panel-wipe {
-  position: fixed;
-  z-index: 48;
-  inset: -12% -30%;
-  pointer-events: none;
-  opacity: 0;
-  transform: translateX(-115%) skewX(-14deg);
-  background:
-    radial-gradient(circle, rgba(20,37,31,.4) 1.6px, transparent 1.7px) 0 0 / 14px 14px,
-    linear-gradient(90deg, var(--cream), var(--paper));
-  border-left: 10px solid var(--ink);
-  border-right: 10px solid var(--ink);
-}
-
-.panel-wipe.wipe { animation: panelWipe .34s cubic-bezier(.6, 0, .3, 1) both; }
-
-@keyframes panelWipe {
-  0% { opacity: 1; transform: translateX(-115%) skewX(-14deg); }
-  45% { opacity: 1; transform: translateX(0) skewX(-14deg); }
-  100% { opacity: 1; transform: translateX(115%) skewX(-14deg); }
 }
 
 .slowmo #game-container { filter: saturate(1.35) contrast(1.06) hue-rotate(-10deg); }

--- a/public/Jungle Run/cappy-3d.js
+++ b/public/Jungle Run/cappy-3d.js
@@ -111,7 +111,6 @@
     slowmoChip: document.getElementById('slowmo-chip'),
     slowmoTime: document.getElementById('slowmo-time'),
     powWord: document.getElementById('pow-word'),
-    panelWipe: document.getElementById('panel-wipe'),
     missionList: document.getElementById('mission-list'),
     musicButton: document.getElementById('music-button'),
     skinOptions: Array.prototype.slice.call(document.querySelectorAll('.skin-option')),
@@ -224,6 +223,7 @@
   let renderer;
   let world;
   let segments = [];
+  let retiredCourses = [];
   let particles = [];
   let audioContext = null;
   let materials;
@@ -644,6 +644,7 @@
   }
 
   function resetSegments(safeStart) {
+    clearRetiredCourses();
     segments.forEach(function (segment) {
       disposeSegmentContent(segment);
       world.remove(segment.root);
@@ -661,26 +662,11 @@
     }
   }
 
-  function rebuildAfterTurn() {
-    segments.forEach(function (segment) {
-      disposeSegmentContent(segment);
-      world.remove(segment.root);
-    });
-    segments = [];
-    for (let i = 0; i < CONFIG.segmentCount; i += 1) {
-      const segment = makeSegment();
-      buildSegment(segment, state.serial, -i * CONFIG.segmentLength, i < 3);
-      state.serial += 1;
-      world.add(segment.root);
-      segments.push(segment);
-    }
-  }
-
   function makeSegment() {
     return { root: new THREE.Group(), obstacles: [], pickups: [], turn: null, qte: null };
   }
 
-  function buildSegment(segment, serial, zPosition, safe) {
+  function buildSegment(segment, serial, zPosition, safe, allowTurns) {
     disposeSegmentContent(segment);
     segment.obstacles = [];
     segment.pickups = [];
@@ -711,7 +697,7 @@
     const powerSegment = !safe && serial >= 6 && serial % 8 === 4;
     const powerType = ['FRUIT', 'MAGNET', 'STAR', 'SLOWMO'][Math.floor(serial / 8) % 4];
     const superchargeSegment = !safe && serial >= 10 && serial % 14 === 9;
-    const shouldTurn = !safe && !needsRecovery && serial >= 7 && serial - state.lastTurnSerial >= stage.turnGap;
+    const shouldEvent = !safe && !needsRecovery && serial >= 7 && serial - state.lastTurnSerial >= stage.turnGap;
     if (superchargeSegment) {
       const superchargeLane = Math.floor(seeded(serial * 53) * 3);
       addCoinTrail(segment, superchargeLane, -8, 7, 0.82);
@@ -720,13 +706,13 @@
       const powerLane = Math.floor(seeded(serial * 31) * 3);
       addCoinTrail(segment, powerLane, -8, 7, 0.82);
       addPickup(segment, powerType, powerLane, 3.1, 1.05);
-    } else if (shouldTurn) {
+    } else if (shouldEvent) {
       const eventRoll = seeded(serial * 71);
-      if (eventRoll < 0.55) {
+      if (eventRoll < 0.55 && allowTurns !== false) {
         const direction = seeded(serial * 17) > 0.5 ? 1 : -1;
         addTurnGate(segment, direction);
       } else {
-        addQteGate(segment, eventRoll < 0.78 ? 'leap' : 'duck');
+        addQteGate(segment, seeded(serial * 83) > 0.5 ? 'leap' : 'duck');
       }
       state.lastTurnSerial = serial;
       state.lastHazardSerial = serial;
@@ -1240,16 +1226,6 @@
     gate.position.z = -1;
     segment.root.add(gate);
 
-    const branch = inkedMesh(new THREE.BoxGeometry(19, 0.16, 7.05), materials.pathLight);
-    branch.position.set(direction * 9.4, -0.09, 0);
-    gate.add(branch);
-    for (let i = 0; i < 4; i += 1) {
-      const tree = createTree(direction * (6 + i * 3.4), -4.4, seeded(i * 5 + 2));
-      gate.add(tree);
-      const treeNear = createTree(direction * (7.5 + i * 3.4), 4.3, seeded(i * 9 + 4));
-      gate.add(treeNear);
-    }
-
     addSignBoard(gate, direction < 0 ? '←' : '→');
 
     const deadEnd = new THREE.Group();
@@ -1264,8 +1240,56 @@
       deadEnd.add(vine);
     }
 
-    segment.turn = { direction: direction, root: segment.root, deadEnd: deadEnd, resolved: false, prompted: false };
+    segment.turn = {
+      direction: direction,
+      root: segment.root,
+      deadEnd: deadEnd,
+      firstExitSerial: segment.root.userData.serial + 1,
+      previewStageIndex: -1,
+      outgoingSegments: [],
+      resolved: false,
+      prompted: false,
+    };
     addCoinTrail(segment, 1, -9, -4, 0.82);
+  }
+
+  function ensureTurnExit(segment, turn) {
+    if (turn.outgoingSegments.length && turn.previewStageIndex === state.stageIndex) return;
+    turn.outgoingSegments.forEach(function (outgoing) {
+      disposeSegmentContent(outgoing);
+      if (outgoing.root.parent) outgoing.root.parent.remove(outgoing.root);
+    });
+    turn.outgoingSegments = createTurnExit(segment, turn.direction, turn.firstExitSerial);
+    turn.previewLastEventSerial = turn.outgoingSegments.reduce(function (lastSerial, outgoing) {
+      return outgoing.qte ? Math.max(lastSerial, outgoing.root.userData.serial) : lastSerial;
+    }, turn.firstExitSerial - 1);
+    turn.previewStageIndex = state.stageIndex;
+  }
+
+  function createTurnExit(segment, direction, firstSerial) {
+    const outgoingSegments = [];
+    const previousLastHazardSerial = state.lastHazardSerial;
+    const previousLastTurnSerial = state.lastTurnSerial;
+
+    for (let index = 0; index < CONFIG.segmentCount; index += 1) {
+      const outgoing = makeSegment();
+      const serial = firstSerial + index;
+      buildSegment(outgoing, serial, 0, index < 3, false);
+      outgoing.root.position.set(
+        direction * (CONFIG.segmentLength / 2 + index * CONFIG.segmentLength),
+        0,
+        -1
+      );
+      outgoing.root.rotation.y = -direction * Math.PI / 2;
+      outgoing.root.userData.turnExit = true;
+      segment.root.add(outgoing.root);
+      outgoingSegments.push(outgoing);
+    }
+
+    // Preview generation must not alter the live straight-course scheduler.
+    state.lastHazardSerial = previousLastHazardSerial;
+    state.lastTurnSerial = previousLastTurnSerial;
+    return outgoingSegments;
   }
 
   function addSignBoard(gate, glyph) {
@@ -1439,6 +1463,7 @@
   }
 
   function moveSegments(distance) {
+    moveRetiredCourses(distance);
     segments.forEach(function (segment) { segment.root.position.z += distance; });
     const first = segments[0];
     if (first && first.root.position.z > CONFIG.removeZ) {
@@ -1448,6 +1473,45 @@
       state.serial += 1;
       segments.push(first);
     }
+  }
+
+  function retireIncomingCourse(incomingSegments) {
+    if (!incomingSegments.length) return;
+    const retiredRoot = new THREE.Group();
+    scene.add(retiredRoot);
+    world.updateMatrixWorld(true);
+    incomingSegments.forEach(function (segment) {
+      retiredRoot.attach(segment.root);
+    });
+    retiredCourses.push({ root: retiredRoot, segments: incomingSegments, distance: 0 });
+  }
+
+  function moveRetiredCourses(distance) {
+    for (let index = retiredCourses.length - 1; index >= 0; index -= 1) {
+      const course = retiredCourses[index];
+      course.distance += distance;
+      course.root.position.z += distance;
+      if (course.distance < CONFIG.segmentLength * 1.35) continue;
+      course.segments.forEach(function (segment) { disposeSegmentContent(segment); });
+      scene.remove(course.root);
+      retiredCourses.splice(index, 1);
+    }
+  }
+
+  function clearRetiredCourses() {
+    retiredCourses.forEach(function (course) {
+      course.segments.forEach(function (segment) { disposeSegmentContent(segment); });
+      if (scene) scene.remove(course.root);
+    });
+    retiredCourses = [];
+  }
+
+  function discardTurnExit(animation) {
+    if (!animation || !animation.outgoingSegments) return;
+    animation.outgoingSegments.forEach(function (segment) {
+      disposeSegmentContent(segment);
+      world.remove(segment.root);
+    });
   }
 
   function updatePlayer(dt, timestamp) {
@@ -1678,6 +1742,7 @@
       const turn = segment.turn;
       if (turn && !turn.resolved) {
         const z = turn.root.position.z - 1;
+        if (z > CONFIG.turnPromptZ - CONFIG.segmentLength) ensureTurnExit(segment, turn);
         if (!turn.prompted && z > CONFIG.turnPromptZ) {
           turn.prompted = true;
           state.activeTurn = turn;
@@ -1740,6 +1805,8 @@
 
   function beginTurn(turn) {
     if (!turn || turn.resolved) return;
+    const turnSegment = segments.find(function (segment) { return segment.root === turn.root; });
+    if (turnSegment) ensureTurnExit(turnSegment, turn);
     turn.resolved = true;
     state.activeTurn = null;
     hideTurnPrompt();
@@ -1749,12 +1816,21 @@
     state.streak += 4;
     state.combo = Math.min(5, 1 + Math.floor(state.streak / 8));
     const pivotZ = turn.root ? turn.root.position.z - 1 : CONFIG.turnBeginZ;
+    const outgoingSegments = turn.outgoingSegments || [];
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      world.attach(segment.root);
+    });
     const arcDuration = (Math.abs(pivotZ) * Math.PI / 2) / Math.max(10, state.speed);
     state.turnAnimation = {
       direction: turn.direction,
       time: 0,
       duration: THREE.MathUtils.clamp(arcDuration, 0.55, 1.1),
       pivotZ: pivotZ,
+      turnSerial: turn.root ? turn.root.userData.serial : state.serial,
+      lastEventSerial: turn.previewLastEventSerial,
+      outgoingSegments: outgoingSegments,
+      incomingSegments: segments.slice(),
     };
     dom.shell.classList.add('turning');
     playSound('turn');
@@ -1770,12 +1846,12 @@
     const arc = Math.sin(progress * Math.PI);
     const yaw = animation.direction * (Math.PI / 2) * eased;
     const pivotZ = animation.pivotZ;
+    const runnerZ = pivotZ * eased;
 
-    // Rotate the whole course around the corner so the camera sweeps
-    // continuously through the turn instead of cutting.
+    // Advance the corner to the player while the prebuilt exit rotates forward.
     world.rotation.y = yaw;
-    world.position.x = -pivotZ * Math.sin(yaw);
-    world.position.z = pivotZ * (1 - Math.cos(yaw));
+    world.position.x = -runnerZ * Math.sin(yaw);
+    world.position.z = -runnerZ * Math.cos(yaw);
 
     camera.position.set(
       player.x * 0.4 + animation.direction * arc * 1.5,
@@ -1788,12 +1864,8 @@
     player.rig.rotation.z = -animation.direction * arc * 0.16;
 
     if (progress >= 1) {
-      // Panel-wipe masks the course re-anchor onto a straight axis.
-      flashPanel();
-      state.lastTurnSerial = state.serial;
-      rebuildAfterTurn();
-      world.rotation.y = 0;
-      world.position.set(0, 0, 0);
+      promoteTurnExit(animation);
+      state.lastTurnSerial = Math.max(animation.turnSerial, animation.lastEventSerial || animation.turnSerial);
       camera.rotation.z = 0;
       camera.position.set(0, 5, 8.6);
       camera.lookAt(0, 0.9, -10.5);
@@ -1804,6 +1876,33 @@
       popWord(animation.direction < 0 ? 'SKRRT!' : 'ZOOM!');
       applyBiome(state.heading);
       bumpStat('turns', 1);
+    }
+  }
+
+  function promoteTurnExit(animation) {
+    const outgoingSegments = animation.outgoingSegments;
+    if (!outgoingSegments.length) return;
+
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      scene.attach(segment.root);
+    });
+    retireIncomingCourse(animation.incomingSegments);
+
+    world.rotation.set(0, 0, 0);
+    world.position.set(0, 0, 0);
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      world.attach(segment.root);
+      delete segment.root.userData.turnExit;
+    });
+    segments = outgoingSegments;
+
+    const finalSerial = outgoingSegments[outgoingSegments.length - 1].root.userData.serial;
+    state.serial = Math.max(state.serial, finalSerial + 1);
+    const hazardSegments = outgoingSegments.filter(function (segment) { return segment.obstacles.length > 0 || segment.qte; });
+    if (hazardSegments.length) {
+      state.lastHazardSerial = hazardSegments[hazardSegments.length - 1].root.userData.serial;
     }
   }
 
@@ -1999,6 +2098,7 @@
     dom.superchargeTime.classList.toggle('hidden', !superchargeActive);
     dom.shell.classList.toggle('supercharged', superchargeActive);
     dom.shell.dataset.gameState = state.mode;
+    dom.shell.dataset.distance = state.distance.toFixed(2);
     dom.shell.dataset.lane = String(player.lane);
     dom.shell.dataset.jumping = String(player.jumping);
     dom.shell.dataset.sliding = String(player.sliding);
@@ -2019,6 +2119,11 @@
     dom.shell.dataset.turnGap = String(STAGES[state.stageIndex].turnGap);
     dom.shell.dataset.activeSegments = String(segments.length);
     dom.shell.dataset.activeTurn = state.activeTurn ? String(state.activeTurn.direction) : '';
+    const visibleTurn = state.turnAnimation || state.activeTurn;
+    dom.shell.dataset.turnPreviewSegments = String(visibleTurn && visibleTurn.outgoingSegments ? visibleTurn.outgoingSegments.length : 0);
+    dom.shell.dataset.retiredCourses = String(retiredCourses.length);
+    dom.shell.dataset.worldX = world ? world.position.x.toFixed(3) : '0.000';
+    dom.shell.dataset.worldZ = world ? world.position.z.toFixed(3) : '0.000';
     if (renderer) {
       dom.shell.dataset.geometries = String(renderer.info.memory.geometries);
       dom.shell.dataset.textures = String(renderer.info.memory.textures);
@@ -2114,6 +2219,7 @@
       : (collision && Number.isFinite(collision.worldZ) ? Math.max(0.68, collision.worldZ + 0.58) : 0);
     state.streak = 0;
     state.superchargeTimer = 0;
+    discardTurnExit(state.turnAnimation);
     state.turnAnimation = null;
     world.rotation.y = 0;
     world.position.set(0, 0, 0);
@@ -2191,6 +2297,7 @@
     state.combo = 1;
     state.shield = 0;
     state.activeTurn = null;
+    discardTurnExit(state.turnAnimation);
     state.turnAnimation = null;
     state.threatCooldown = STAGES[0].threatMin;
     state.crashTimer = 0;
@@ -2349,6 +2456,12 @@
         updateHud();
         return;
       }
+      if (localTest && (key === '8' || key === '9') && state.mode === GAME.RUNNING) {
+        const direction = key === '8' ? 1 : -1;
+        forceTurnForTest(direction, 1);
+        acceptTurn(direction);
+        return;
+      }
       if (localTest && key === 'f' && state.mode === GAME.RUNNING) {
         collectPickup({ type: 'FRUIT', collected: false, mesh: { visible: true } }, new THREE.Vector3(player.x, 0.9, 0));
         updateHud();
@@ -2380,8 +2493,11 @@
         return;
       }
       if (localTest && key === 't' && state.mode === GAME.RUNNING) {
-        state.activeTurn = { direction: 1, resolved: false, prompted: true, root: null };
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 1);
+        return;
+      }
+      if (localTest && key === 'y' && state.mode === GAME.RUNNING) {
+        forceTurnForTest(-1, 0);
         return;
       }
       if (localTest && key === 'v' && state.mode === GAME.RUNNING && !state.threat) {
@@ -2389,17 +2505,11 @@
         return;
       }
       if (localTest && key === 'n' && state.mode === GAME.RUNNING && segments.length) {
-        const testTurn = { direction: 1, resolved: false, prompted: true, root: segments[0].root };
-        segments[0].turn = testTurn;
-        state.activeTurn = testTurn;
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 0);
         return;
       }
       if (localTest && key === 'u' && state.mode === GAME.RUNNING && segments.length > 1) {
-        const bufferedTurn = { direction: 1, resolved: false, prompted: true, root: segments[1].root };
-        segments[1].turn = bufferedTurn;
-        state.activeTurn = bufferedTurn;
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 1);
         return;
       }
       if (localTest && key === 'g' && state.mode === GAME.RUNNING) {
@@ -2566,14 +2676,26 @@
     focusAfterClose();
   }
 
+  function forceTurnForTest(direction, segmentIndex) {
+    if (state.mode !== GAME.RUNNING || !segments.length || state.turnAnimation) return;
+    const targetIndex = Math.min(Math.max(segmentIndex || 0, 0), segments.length - 1);
+    const segment = segments[targetIndex];
+    const serial = segment.root.userData.serial;
+    const zPosition = segment.root.position.z;
+    buildSegment(segment, serial, zPosition, true, false);
+    addTurnGate(segment, direction < 0 ? -1 : 1);
+    segment.turn.prompted = true;
+    state.activeTurn = segment.turn;
+    showEventPrompt(segment.turn.direction < 0 ? '↰' : '↱', segment.turn.direction < 0 ? 'LEFT TURN' : 'RIGHT TURN');
+  }
+
   function setupLocalTestBridge() {
     if (!['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)) return;
     document.addEventListener('cappy:test', function () {
       const action = dom.shell.dataset.testAction;
       if (action === 'force-turn-left' || action === 'force-turn-right') {
         const direction = action.endsWith('left') ? -1 : 1;
-        state.activeTurn = { direction: direction, resolved: false, prompted: true, root: null };
-        showEventPrompt(direction < 0 ? "↰" : "↱", direction < 0 ? "LEFT TURN" : "RIGHT TURN");
+        forceTurnForTest(direction, 1);
       } else if (action === 'left') handleLateral(-1);
       else if (action === 'right') handleLateral(1);
       else if (action === 'jump') jump();
@@ -2670,13 +2792,6 @@
     void dom.powWord.offsetWidth;
     dom.powWord.classList.add('pop');
     state.powTimer = 0.85;
-  }
-
-  function flashPanel() {
-    if (!dom.panelWipe) return;
-    dom.panelWipe.classList.remove('wipe');
-    void dom.panelWipe.offsetWidth;
-    dom.panelWipe.classList.add('wipe');
   }
 
   function syncBestScore() {
@@ -3105,6 +3220,12 @@
           activeSegments: segments.length,
           activeTurn: state.activeTurn ? state.activeTurn.direction : null,
           turning: Boolean(state.turnAnimation),
+          turnPreviewSegments: (state.turnAnimation || state.activeTurn) && (state.turnAnimation || state.activeTurn).outgoingSegments
+            ? (state.turnAnimation || state.activeTurn).outgoingSegments.length
+            : 0,
+          retiredCourses: retiredCourses.length,
+          worldX: Number(world.position.x.toFixed(3)),
+          worldZ: Number(world.position.z.toFixed(3)),
           crashReason: state.crashReason,
           crashStartZ: Number(state.crashStartZ.toFixed(2)),
           lastTurnSerial: state.lastTurnSerial,
@@ -3146,9 +3267,7 @@
         pause: pauseGame,
         resume: resumeGame,
         forceTurn: function (direction) {
-          if (state.mode !== GAME.RUNNING) return;
-          state.activeTurn = { direction: direction < 0 ? -1 : 1, resolved: false, prompted: true, root: null };
-          showEventPrompt(state.activeTurn.direction < 0 ? "↰" : "↱", state.activeTurn.direction < 0 ? "LEFT TURN" : "RIGHT TURN");
+          forceTurnForTest(direction, 1);
         },
         forceThreat: function () {
           if (state.mode === GAME.RUNNING && !state.threat) spawnThreat();

--- a/public/Jungle Run/index.html
+++ b/public/Jungle Run/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#102a22">
-  <meta name="description" content="Cappy Jungle Run — a comic-book 3D endless runner starring the CloseDose capybara mascot.">
+  <meta name="description" content="Cappy Jungle Run — a comic-book 3D endless runner. Sprint from jungle to hot springs, crystal caves and a neon city with the CloseDose capybara mascot.">
   <title>Cappy Jungle Run</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,6 +44,9 @@
         </div>
         <div id="combo-chip" class="combo-chip hidden">FLOW <strong id="hud-combo">x1</strong></div>
         <div id="shield-chip" class="shield-chip hidden">LEAF SHIELD <span id="shield-time">0</span>s</div>
+        <div id="magnet-chip" class="shield-chip power-chip magnet-chip hidden">MAGNET <span id="magnet-time">0</span>s</div>
+        <div id="star-chip" class="shield-chip power-chip star-chip hidden">2&times; SCORE <span id="star-time">0</span>s</div>
+        <div id="slowmo-chip" class="shield-chip power-chip slowmo-chip hidden">SLOW-MO <span id="slowmo-time">0</span>s</div>
       </div>
 
       <div class="hud-cluster hud-best-card">
@@ -76,6 +79,7 @@
 
     <button id="pause-button" class="icon-button pause-button hidden" type="button" aria-label="Pause game">Ⅱ</button>
     <button id="help-button" class="icon-button help-button" type="button" aria-label="Show game controls">?</button>
+    <button id="music-button" class="icon-button music-button" type="button" aria-label="Toggle music" aria-pressed="true">♪</button>
     <button id="close-game-btn" class="icon-button close-button" type="button" aria-label="Exit game">×</button>
 
     <section id="start-screen" class="overlay start-overlay" aria-labelledby="game-title">
@@ -92,12 +96,22 @@
         </div>
 
         <div class="start-footer">
+          <div class="skin-picker" role="radiogroup" aria-label="Choose Cappy's look">
+            <span class="skin-label">SKIN</span>
+            <button class="skin-option" type="button" data-skin="classic" role="radio" aria-checked="true">CLASSIC</button>
+            <button class="skin-option" type="button" data-skin="ink" role="radio" aria-checked="false">COMIC INK</button>
+          </div>
           <button id="start-button" class="comic-button" type="button">
             <span>START RUN</span><b>→</b>
           </button>
           <button id="start-help-button" class="text-button help-text-button" type="button">How to run</button>
           <div class="best-line">Best score <strong id="start-highscore">00000</strong></div>
         </div>
+
+        <aside class="mission-board" aria-label="Missions">
+          <span class="mission-board-title">MISSIONS</span>
+          <ul id="mission-list"></ul>
+        </aside>
       </div>
     </section>
 
@@ -111,13 +125,13 @@
             <span class="guide-number">01</span>
             <div class="guide-keys"><kbd>←</kbd><kbd>→</kbd><b>or swipe</b></div>
             <strong>Dodge / pivot</strong>
-            <p>Move across three lanes. At a corner, swipe toward the giant path arrow and keep running straight into the next stretch.</p>
+            <p>Move across three lanes. At a corner, swipe toward the giant path arrow and the camera carries you around the bend.</p>
           </article>
           <article>
             <span class="guide-number">02</span>
             <div class="guide-keys"><kbd>↑</kbd><kbd>↓</kbd><b>or swipe</b></div>
             <strong>Jump / slide</strong>
-            <p>Jump logs, marked pits and broken paths. Slide beneath vines and temple bars.</p>
+            <p>Jump logs, pits and gorge gaps. Slide beneath vines, low branches and temple bars. Watch for ↑ and ↓ signs — they call the move.</p>
           </article>
           <article class="boost-guide">
             <span class="guide-number">03</span>
@@ -165,9 +179,10 @@
       </div>
     </section>
 
+    <div id="pow-word" class="pow-word hidden" aria-hidden="true"></div>
     <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
   </main>
 
-  <script src="cappy-3d.js"></script>
+  <script src="cappy-3d.js?v=20260718-continuous-turns"></script>
 </body>
 </html>

--- a/public/junglerun/cappy-3d.css
+++ b/public/junglerun/cappy-3d.css
@@ -99,8 +99,7 @@ a:focus-visible {
 }
 
 .comic-grain,
-.speed-lines,
-.panel-wipe {
+.speed-lines {
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -1206,28 +1205,6 @@ h1 em {
   30% { transform: translate(-50%, -50%) scale(1) rotate(-1.5deg); }
   78% { opacity: 1; }
   100% { opacity: 0; transform: translate(-50%, -56%) scale(.92) rotate(-1.5deg); }
-}
-
-.panel-wipe {
-  position: fixed;
-  z-index: 48;
-  inset: -12% -30%;
-  pointer-events: none;
-  opacity: 0;
-  transform: translateX(-115%) skewX(-14deg);
-  background:
-    radial-gradient(circle, rgba(20,37,31,.4) 1.6px, transparent 1.7px) 0 0 / 14px 14px,
-    linear-gradient(90deg, var(--cream), var(--paper));
-  border-left: 10px solid var(--ink);
-  border-right: 10px solid var(--ink);
-}
-
-.panel-wipe.wipe { animation: panelWipe .34s cubic-bezier(.6, 0, .3, 1) both; }
-
-@keyframes panelWipe {
-  0% { opacity: 1; transform: translateX(-115%) skewX(-14deg); }
-  45% { opacity: 1; transform: translateX(0) skewX(-14deg); }
-  100% { opacity: 1; transform: translateX(115%) skewX(-14deg); }
 }
 
 .slowmo #game-container { filter: saturate(1.35) contrast(1.06) hue-rotate(-10deg); }

--- a/public/junglerun/cappy-3d.js
+++ b/public/junglerun/cappy-3d.js
@@ -111,7 +111,6 @@
     slowmoChip: document.getElementById('slowmo-chip'),
     slowmoTime: document.getElementById('slowmo-time'),
     powWord: document.getElementById('pow-word'),
-    panelWipe: document.getElementById('panel-wipe'),
     missionList: document.getElementById('mission-list'),
     musicButton: document.getElementById('music-button'),
     skinOptions: Array.prototype.slice.call(document.querySelectorAll('.skin-option')),
@@ -224,6 +223,7 @@
   let renderer;
   let world;
   let segments = [];
+  let retiredCourses = [];
   let particles = [];
   let audioContext = null;
   let materials;
@@ -644,6 +644,7 @@
   }
 
   function resetSegments(safeStart) {
+    clearRetiredCourses();
     segments.forEach(function (segment) {
       disposeSegmentContent(segment);
       world.remove(segment.root);
@@ -661,26 +662,11 @@
     }
   }
 
-  function rebuildAfterTurn() {
-    segments.forEach(function (segment) {
-      disposeSegmentContent(segment);
-      world.remove(segment.root);
-    });
-    segments = [];
-    for (let i = 0; i < CONFIG.segmentCount; i += 1) {
-      const segment = makeSegment();
-      buildSegment(segment, state.serial, -i * CONFIG.segmentLength, i < 3);
-      state.serial += 1;
-      world.add(segment.root);
-      segments.push(segment);
-    }
-  }
-
   function makeSegment() {
     return { root: new THREE.Group(), obstacles: [], pickups: [], turn: null, qte: null };
   }
 
-  function buildSegment(segment, serial, zPosition, safe) {
+  function buildSegment(segment, serial, zPosition, safe, allowTurns) {
     disposeSegmentContent(segment);
     segment.obstacles = [];
     segment.pickups = [];
@@ -711,7 +697,7 @@
     const powerSegment = !safe && serial >= 6 && serial % 8 === 4;
     const powerType = ['FRUIT', 'MAGNET', 'STAR', 'SLOWMO'][Math.floor(serial / 8) % 4];
     const superchargeSegment = !safe && serial >= 10 && serial % 14 === 9;
-    const shouldTurn = !safe && !needsRecovery && serial >= 7 && serial - state.lastTurnSerial >= stage.turnGap;
+    const shouldEvent = !safe && !needsRecovery && serial >= 7 && serial - state.lastTurnSerial >= stage.turnGap;
     if (superchargeSegment) {
       const superchargeLane = Math.floor(seeded(serial * 53) * 3);
       addCoinTrail(segment, superchargeLane, -8, 7, 0.82);
@@ -720,13 +706,13 @@
       const powerLane = Math.floor(seeded(serial * 31) * 3);
       addCoinTrail(segment, powerLane, -8, 7, 0.82);
       addPickup(segment, powerType, powerLane, 3.1, 1.05);
-    } else if (shouldTurn) {
+    } else if (shouldEvent) {
       const eventRoll = seeded(serial * 71);
-      if (eventRoll < 0.55) {
+      if (eventRoll < 0.55 && allowTurns !== false) {
         const direction = seeded(serial * 17) > 0.5 ? 1 : -1;
         addTurnGate(segment, direction);
       } else {
-        addQteGate(segment, eventRoll < 0.78 ? 'leap' : 'duck');
+        addQteGate(segment, seeded(serial * 83) > 0.5 ? 'leap' : 'duck');
       }
       state.lastTurnSerial = serial;
       state.lastHazardSerial = serial;
@@ -1240,16 +1226,6 @@
     gate.position.z = -1;
     segment.root.add(gate);
 
-    const branch = inkedMesh(new THREE.BoxGeometry(19, 0.16, 7.05), materials.pathLight);
-    branch.position.set(direction * 9.4, -0.09, 0);
-    gate.add(branch);
-    for (let i = 0; i < 4; i += 1) {
-      const tree = createTree(direction * (6 + i * 3.4), -4.4, seeded(i * 5 + 2));
-      gate.add(tree);
-      const treeNear = createTree(direction * (7.5 + i * 3.4), 4.3, seeded(i * 9 + 4));
-      gate.add(treeNear);
-    }
-
     addSignBoard(gate, direction < 0 ? '←' : '→');
 
     const deadEnd = new THREE.Group();
@@ -1264,8 +1240,56 @@
       deadEnd.add(vine);
     }
 
-    segment.turn = { direction: direction, root: segment.root, deadEnd: deadEnd, resolved: false, prompted: false };
+    segment.turn = {
+      direction: direction,
+      root: segment.root,
+      deadEnd: deadEnd,
+      firstExitSerial: segment.root.userData.serial + 1,
+      previewStageIndex: -1,
+      outgoingSegments: [],
+      resolved: false,
+      prompted: false,
+    };
     addCoinTrail(segment, 1, -9, -4, 0.82);
+  }
+
+  function ensureTurnExit(segment, turn) {
+    if (turn.outgoingSegments.length && turn.previewStageIndex === state.stageIndex) return;
+    turn.outgoingSegments.forEach(function (outgoing) {
+      disposeSegmentContent(outgoing);
+      if (outgoing.root.parent) outgoing.root.parent.remove(outgoing.root);
+    });
+    turn.outgoingSegments = createTurnExit(segment, turn.direction, turn.firstExitSerial);
+    turn.previewLastEventSerial = turn.outgoingSegments.reduce(function (lastSerial, outgoing) {
+      return outgoing.qte ? Math.max(lastSerial, outgoing.root.userData.serial) : lastSerial;
+    }, turn.firstExitSerial - 1);
+    turn.previewStageIndex = state.stageIndex;
+  }
+
+  function createTurnExit(segment, direction, firstSerial) {
+    const outgoingSegments = [];
+    const previousLastHazardSerial = state.lastHazardSerial;
+    const previousLastTurnSerial = state.lastTurnSerial;
+
+    for (let index = 0; index < CONFIG.segmentCount; index += 1) {
+      const outgoing = makeSegment();
+      const serial = firstSerial + index;
+      buildSegment(outgoing, serial, 0, index < 3, false);
+      outgoing.root.position.set(
+        direction * (CONFIG.segmentLength / 2 + index * CONFIG.segmentLength),
+        0,
+        -1
+      );
+      outgoing.root.rotation.y = -direction * Math.PI / 2;
+      outgoing.root.userData.turnExit = true;
+      segment.root.add(outgoing.root);
+      outgoingSegments.push(outgoing);
+    }
+
+    // Preview generation must not alter the live straight-course scheduler.
+    state.lastHazardSerial = previousLastHazardSerial;
+    state.lastTurnSerial = previousLastTurnSerial;
+    return outgoingSegments;
   }
 
   function addSignBoard(gate, glyph) {
@@ -1439,6 +1463,7 @@
   }
 
   function moveSegments(distance) {
+    moveRetiredCourses(distance);
     segments.forEach(function (segment) { segment.root.position.z += distance; });
     const first = segments[0];
     if (first && first.root.position.z > CONFIG.removeZ) {
@@ -1448,6 +1473,45 @@
       state.serial += 1;
       segments.push(first);
     }
+  }
+
+  function retireIncomingCourse(incomingSegments) {
+    if (!incomingSegments.length) return;
+    const retiredRoot = new THREE.Group();
+    scene.add(retiredRoot);
+    world.updateMatrixWorld(true);
+    incomingSegments.forEach(function (segment) {
+      retiredRoot.attach(segment.root);
+    });
+    retiredCourses.push({ root: retiredRoot, segments: incomingSegments, distance: 0 });
+  }
+
+  function moveRetiredCourses(distance) {
+    for (let index = retiredCourses.length - 1; index >= 0; index -= 1) {
+      const course = retiredCourses[index];
+      course.distance += distance;
+      course.root.position.z += distance;
+      if (course.distance < CONFIG.segmentLength * 1.35) continue;
+      course.segments.forEach(function (segment) { disposeSegmentContent(segment); });
+      scene.remove(course.root);
+      retiredCourses.splice(index, 1);
+    }
+  }
+
+  function clearRetiredCourses() {
+    retiredCourses.forEach(function (course) {
+      course.segments.forEach(function (segment) { disposeSegmentContent(segment); });
+      if (scene) scene.remove(course.root);
+    });
+    retiredCourses = [];
+  }
+
+  function discardTurnExit(animation) {
+    if (!animation || !animation.outgoingSegments) return;
+    animation.outgoingSegments.forEach(function (segment) {
+      disposeSegmentContent(segment);
+      world.remove(segment.root);
+    });
   }
 
   function updatePlayer(dt, timestamp) {
@@ -1678,6 +1742,7 @@
       const turn = segment.turn;
       if (turn && !turn.resolved) {
         const z = turn.root.position.z - 1;
+        if (z > CONFIG.turnPromptZ - CONFIG.segmentLength) ensureTurnExit(segment, turn);
         if (!turn.prompted && z > CONFIG.turnPromptZ) {
           turn.prompted = true;
           state.activeTurn = turn;
@@ -1740,6 +1805,8 @@
 
   function beginTurn(turn) {
     if (!turn || turn.resolved) return;
+    const turnSegment = segments.find(function (segment) { return segment.root === turn.root; });
+    if (turnSegment) ensureTurnExit(turnSegment, turn);
     turn.resolved = true;
     state.activeTurn = null;
     hideTurnPrompt();
@@ -1749,12 +1816,21 @@
     state.streak += 4;
     state.combo = Math.min(5, 1 + Math.floor(state.streak / 8));
     const pivotZ = turn.root ? turn.root.position.z - 1 : CONFIG.turnBeginZ;
+    const outgoingSegments = turn.outgoingSegments || [];
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      world.attach(segment.root);
+    });
     const arcDuration = (Math.abs(pivotZ) * Math.PI / 2) / Math.max(10, state.speed);
     state.turnAnimation = {
       direction: turn.direction,
       time: 0,
       duration: THREE.MathUtils.clamp(arcDuration, 0.55, 1.1),
       pivotZ: pivotZ,
+      turnSerial: turn.root ? turn.root.userData.serial : state.serial,
+      lastEventSerial: turn.previewLastEventSerial,
+      outgoingSegments: outgoingSegments,
+      incomingSegments: segments.slice(),
     };
     dom.shell.classList.add('turning');
     playSound('turn');
@@ -1770,12 +1846,12 @@
     const arc = Math.sin(progress * Math.PI);
     const yaw = animation.direction * (Math.PI / 2) * eased;
     const pivotZ = animation.pivotZ;
+    const runnerZ = pivotZ * eased;
 
-    // Rotate the whole course around the corner so the camera sweeps
-    // continuously through the turn instead of cutting.
+    // Advance the corner to the player while the prebuilt exit rotates forward.
     world.rotation.y = yaw;
-    world.position.x = -pivotZ * Math.sin(yaw);
-    world.position.z = pivotZ * (1 - Math.cos(yaw));
+    world.position.x = -runnerZ * Math.sin(yaw);
+    world.position.z = -runnerZ * Math.cos(yaw);
 
     camera.position.set(
       player.x * 0.4 + animation.direction * arc * 1.5,
@@ -1788,12 +1864,8 @@
     player.rig.rotation.z = -animation.direction * arc * 0.16;
 
     if (progress >= 1) {
-      // Panel-wipe masks the course re-anchor onto a straight axis.
-      flashPanel();
-      state.lastTurnSerial = state.serial;
-      rebuildAfterTurn();
-      world.rotation.y = 0;
-      world.position.set(0, 0, 0);
+      promoteTurnExit(animation);
+      state.lastTurnSerial = Math.max(animation.turnSerial, animation.lastEventSerial || animation.turnSerial);
       camera.rotation.z = 0;
       camera.position.set(0, 5, 8.6);
       camera.lookAt(0, 0.9, -10.5);
@@ -1804,6 +1876,33 @@
       popWord(animation.direction < 0 ? 'SKRRT!' : 'ZOOM!');
       applyBiome(state.heading);
       bumpStat('turns', 1);
+    }
+  }
+
+  function promoteTurnExit(animation) {
+    const outgoingSegments = animation.outgoingSegments;
+    if (!outgoingSegments.length) return;
+
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      scene.attach(segment.root);
+    });
+    retireIncomingCourse(animation.incomingSegments);
+
+    world.rotation.set(0, 0, 0);
+    world.position.set(0, 0, 0);
+    world.updateMatrixWorld(true);
+    outgoingSegments.forEach(function (segment) {
+      world.attach(segment.root);
+      delete segment.root.userData.turnExit;
+    });
+    segments = outgoingSegments;
+
+    const finalSerial = outgoingSegments[outgoingSegments.length - 1].root.userData.serial;
+    state.serial = Math.max(state.serial, finalSerial + 1);
+    const hazardSegments = outgoingSegments.filter(function (segment) { return segment.obstacles.length > 0 || segment.qte; });
+    if (hazardSegments.length) {
+      state.lastHazardSerial = hazardSegments[hazardSegments.length - 1].root.userData.serial;
     }
   }
 
@@ -1999,6 +2098,7 @@
     dom.superchargeTime.classList.toggle('hidden', !superchargeActive);
     dom.shell.classList.toggle('supercharged', superchargeActive);
     dom.shell.dataset.gameState = state.mode;
+    dom.shell.dataset.distance = state.distance.toFixed(2);
     dom.shell.dataset.lane = String(player.lane);
     dom.shell.dataset.jumping = String(player.jumping);
     dom.shell.dataset.sliding = String(player.sliding);
@@ -2019,6 +2119,11 @@
     dom.shell.dataset.turnGap = String(STAGES[state.stageIndex].turnGap);
     dom.shell.dataset.activeSegments = String(segments.length);
     dom.shell.dataset.activeTurn = state.activeTurn ? String(state.activeTurn.direction) : '';
+    const visibleTurn = state.turnAnimation || state.activeTurn;
+    dom.shell.dataset.turnPreviewSegments = String(visibleTurn && visibleTurn.outgoingSegments ? visibleTurn.outgoingSegments.length : 0);
+    dom.shell.dataset.retiredCourses = String(retiredCourses.length);
+    dom.shell.dataset.worldX = world ? world.position.x.toFixed(3) : '0.000';
+    dom.shell.dataset.worldZ = world ? world.position.z.toFixed(3) : '0.000';
     if (renderer) {
       dom.shell.dataset.geometries = String(renderer.info.memory.geometries);
       dom.shell.dataset.textures = String(renderer.info.memory.textures);
@@ -2114,6 +2219,7 @@
       : (collision && Number.isFinite(collision.worldZ) ? Math.max(0.68, collision.worldZ + 0.58) : 0);
     state.streak = 0;
     state.superchargeTimer = 0;
+    discardTurnExit(state.turnAnimation);
     state.turnAnimation = null;
     world.rotation.y = 0;
     world.position.set(0, 0, 0);
@@ -2191,6 +2297,7 @@
     state.combo = 1;
     state.shield = 0;
     state.activeTurn = null;
+    discardTurnExit(state.turnAnimation);
     state.turnAnimation = null;
     state.threatCooldown = STAGES[0].threatMin;
     state.crashTimer = 0;
@@ -2349,6 +2456,12 @@
         updateHud();
         return;
       }
+      if (localTest && (key === '8' || key === '9') && state.mode === GAME.RUNNING) {
+        const direction = key === '8' ? 1 : -1;
+        forceTurnForTest(direction, 1);
+        acceptTurn(direction);
+        return;
+      }
       if (localTest && key === 'f' && state.mode === GAME.RUNNING) {
         collectPickup({ type: 'FRUIT', collected: false, mesh: { visible: true } }, new THREE.Vector3(player.x, 0.9, 0));
         updateHud();
@@ -2380,8 +2493,11 @@
         return;
       }
       if (localTest && key === 't' && state.mode === GAME.RUNNING) {
-        state.activeTurn = { direction: 1, resolved: false, prompted: true, root: null };
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 1);
+        return;
+      }
+      if (localTest && key === 'y' && state.mode === GAME.RUNNING) {
+        forceTurnForTest(-1, 0);
         return;
       }
       if (localTest && key === 'v' && state.mode === GAME.RUNNING && !state.threat) {
@@ -2389,17 +2505,11 @@
         return;
       }
       if (localTest && key === 'n' && state.mode === GAME.RUNNING && segments.length) {
-        const testTurn = { direction: 1, resolved: false, prompted: true, root: segments[0].root };
-        segments[0].turn = testTurn;
-        state.activeTurn = testTurn;
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 0);
         return;
       }
       if (localTest && key === 'u' && state.mode === GAME.RUNNING && segments.length > 1) {
-        const bufferedTurn = { direction: 1, resolved: false, prompted: true, root: segments[1].root };
-        segments[1].turn = bufferedTurn;
-        state.activeTurn = bufferedTurn;
-        showEventPrompt("↱", "RIGHT TURN");
+        forceTurnForTest(1, 1);
         return;
       }
       if (localTest && key === 'g' && state.mode === GAME.RUNNING) {
@@ -2566,14 +2676,26 @@
     focusAfterClose();
   }
 
+  function forceTurnForTest(direction, segmentIndex) {
+    if (state.mode !== GAME.RUNNING || !segments.length || state.turnAnimation) return;
+    const targetIndex = Math.min(Math.max(segmentIndex || 0, 0), segments.length - 1);
+    const segment = segments[targetIndex];
+    const serial = segment.root.userData.serial;
+    const zPosition = segment.root.position.z;
+    buildSegment(segment, serial, zPosition, true, false);
+    addTurnGate(segment, direction < 0 ? -1 : 1);
+    segment.turn.prompted = true;
+    state.activeTurn = segment.turn;
+    showEventPrompt(segment.turn.direction < 0 ? '↰' : '↱', segment.turn.direction < 0 ? 'LEFT TURN' : 'RIGHT TURN');
+  }
+
   function setupLocalTestBridge() {
     if (!['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)) return;
     document.addEventListener('cappy:test', function () {
       const action = dom.shell.dataset.testAction;
       if (action === 'force-turn-left' || action === 'force-turn-right') {
         const direction = action.endsWith('left') ? -1 : 1;
-        state.activeTurn = { direction: direction, resolved: false, prompted: true, root: null };
-        showEventPrompt(direction < 0 ? "↰" : "↱", direction < 0 ? "LEFT TURN" : "RIGHT TURN");
+        forceTurnForTest(direction, 1);
       } else if (action === 'left') handleLateral(-1);
       else if (action === 'right') handleLateral(1);
       else if (action === 'jump') jump();
@@ -2670,13 +2792,6 @@
     void dom.powWord.offsetWidth;
     dom.powWord.classList.add('pop');
     state.powTimer = 0.85;
-  }
-
-  function flashPanel() {
-    if (!dom.panelWipe) return;
-    dom.panelWipe.classList.remove('wipe');
-    void dom.panelWipe.offsetWidth;
-    dom.panelWipe.classList.add('wipe');
   }
 
   function syncBestScore() {
@@ -3105,6 +3220,12 @@
           activeSegments: segments.length,
           activeTurn: state.activeTurn ? state.activeTurn.direction : null,
           turning: Boolean(state.turnAnimation),
+          turnPreviewSegments: (state.turnAnimation || state.activeTurn) && (state.turnAnimation || state.activeTurn).outgoingSegments
+            ? (state.turnAnimation || state.activeTurn).outgoingSegments.length
+            : 0,
+          retiredCourses: retiredCourses.length,
+          worldX: Number(world.position.x.toFixed(3)),
+          worldZ: Number(world.position.z.toFixed(3)),
           crashReason: state.crashReason,
           crashStartZ: Number(state.crashStartZ.toFixed(2)),
           lastTurnSerial: state.lastTurnSerial,
@@ -3146,9 +3267,7 @@
         pause: pauseGame,
         resume: resumeGame,
         forceTurn: function (direction) {
-          if (state.mode !== GAME.RUNNING) return;
-          state.activeTurn = { direction: direction < 0 ? -1 : 1, resolved: false, prompted: true, root: null };
-          showEventPrompt(state.activeTurn.direction < 0 ? "↰" : "↱", state.activeTurn.direction < 0 ? "LEFT TURN" : "RIGHT TURN");
+          forceTurnForTest(direction, 1);
         },
         forceThreat: function () {
           if (state.mode === GAME.RUNNING && !state.threat) spawnThreat();

--- a/public/junglerun/index.html
+++ b/public/junglerun/index.html
@@ -180,11 +180,9 @@
     </section>
 
     <div id="pow-word" class="pow-word hidden" aria-hidden="true"></div>
-    <div id="panel-wipe" class="panel-wipe" aria-hidden="true"></div>
-
     <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
   </main>
 
-  <script src="cappy-3d.js"></script>
+  <script src="cappy-3d.js?v=20260718-continuous-turns"></script>
 </body>
 </html>


### PR DESCRIPTION
## **User description**
## Summary
- prebuild the outgoing track before every left/right turn so the path remains visible through the bend
- rotate and promote the existing track geometry continuously instead of masking a course rebuild with a screen wipe
- preserve biome event spacing, QTEs, and outgoing-course cleanup across turns
- keep the lowercase and spaced Jungle Run routes in sync and remove the obsolete wipe markup/styles

## Verification
- `node --check` on both production script copies
- `git diff --check`
- verified all 55 JavaScript-required DOM IDs and local asset references on both routes
- browser-tested right and left turns, including a biome change during approach
- final right-turn test retained 9 preview segments during the turn and 9 active segments after promotion, with the run still `RUNNING`
- independent code review: merge-ready


___

## **CodeAnt-AI Description**
**Make Jungle Run turns flow continuously**

### What Changed
- Corner turns now carry the course into the next stretch instead of cutting to a screen wipe, so the run stays visible through the bend
- The old wipe effect was removed from the game
- Turn previews are generated ahead of time, which keeps turns, prompts, and follow-up path behavior aligned during the bend
- The run now keeps track of the current distance and turn preview state for smoother on-screen status updates

### Impact
`✅ Smoother corner turns`
`✅ No screen-wipe interruption on turns`
`✅ Clearer turn timing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
