### PR TITLE
Improve Jungle Run landing layout

### DIFF
--- a/public/junglerun/cappy-3d.css
+++ b/public/junglerun/cappy-3d.css
@@ -643,15 +643,22 @@ a:focus-visible {
 }
 
 .start-overlay {
-  grid-template-columns: minmax(350px, 720px);
-  justify-content: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.start-layout {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 660px) minmax(244px, 300px);
+  align-items: center;
+  gap: clamp(1.25rem, 2.5vw, 2.25rem);
+  width: min(100%, 1000px);
 }
 
 .title-panel,
 .pause-card,
 .gameover-card {
   position: relative;
-  width: min(100%, 660px);
   min-height: min(82vh, 740px);
   padding: clamp(1.4rem, 4vw, 3rem);
   overflow: hidden;
@@ -661,6 +668,15 @@ a:focus-visible {
   border: 6px solid var(--ink);
   box-shadow: 14px 14px 0 rgba(8,26,21,.92);
   transform: rotate(-.7deg);
+}
+
+.title-panel {
+  width: 100%;
+}
+
+.pause-card,
+.gameover-card {
+  width: min(100%, 660px);
 }
 
 .issue-label,
@@ -785,6 +801,13 @@ h1 em {
   flex-direction: column;
   align-items: flex-start;
   gap: .8rem;
+}
+
+.start-secondary-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: .7rem;
 }
 
 .comic-button {
@@ -1076,19 +1099,14 @@ h1 em {
 #game-shell.running > .music-button { display: none; }
 
 .skin-picker {
-  display: flex;
-  align-items: center;
-  gap: .45rem;
-}
-
-.skin-label {
-  font-family: var(--display);
-  font-size: .62rem;
-  letter-spacing: .1em;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: .65rem;
 }
 
 .skin-option {
-  padding: .38rem .7rem;
+  min-height: 3rem;
+  padding: .65rem .8rem;
   border: 3px solid var(--ink);
   background: var(--paper);
   box-shadow: 3px 3px 0 var(--ink);
@@ -1096,10 +1114,11 @@ h1 em {
   font-size: .6rem;
   letter-spacing: .05em;
   cursor: pointer;
-  transition: transform .12s ease;
+  transition: transform .16s ease, box-shadow .16s ease, background .16s ease;
 }
 
-.skin-option:hover { transform: translateY(-2px); }
+.skin-option:hover { transform: translate(-2px, -2px); box-shadow: 5px 5px 0 var(--ink); }
+.skin-option:active { transform: translate(2px, 2px); box-shadow: 1px 1px 0 var(--ink); }
 
 .skin-option.selected {
   background: var(--ink);
@@ -1116,29 +1135,55 @@ h1 em {
 
 .skin-ink .mascot-stage img { filter: grayscale(1) contrast(1.45) brightness(1.06); }
 
-.mission-board {
-  position: absolute;
-  z-index: 3;
-  right: clamp(1.2rem, 3.4vw, 2.6rem);
-  bottom: clamp(1.4rem, 4vw, 3rem);
-  width: min(300px, 34vw);
-  padding: .7rem .8rem .8rem;
+.start-sidebar {
+  position: relative;
+  z-index: 4;
+  display: grid;
+  gap: 1.25rem;
+  width: 100%;
+}
+
+.sidebar-card {
+  position: relative;
+  padding: 1.05rem;
   background: var(--cream);
-  border: 3px solid var(--ink);
-  box-shadow: 5px 5px 0 var(--ink), -4px 4px 0 var(--stage-accent);
-  transform: rotate(1.2deg);
+  border: 4px solid var(--ink);
+  box-shadow: 8px 8px 0 var(--ink);
+}
+
+.skin-sidebar {
+  transform: rotate(1deg);
+}
+
+.mission-board {
+  transform: rotate(-.7deg);
+  box-shadow: 8px 8px 0 var(--ink), -5px 5px 0 var(--stage-accent);
+}
+
+.sidebar-toggle {
+  display: none;
+}
+
+.sidebar-panel {
+  display: block;
+}
+
+.sidebar-title {
+  margin: 0 0 .85rem;
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: .82rem;
+  line-height: 1;
+  letter-spacing: .08em;
 }
 
 .mission-board-title {
   display: inline-block;
-  margin: -1.35rem 0 .4rem;
-  padding: .22rem .6rem;
+  margin: -.25rem 0 .8rem;
+  padding: .3rem .65rem;
   background: var(--coral);
   color: var(--cream);
   border: 3px solid var(--ink);
-  font-family: var(--display);
-  font-size: .66rem;
-  letter-spacing: .08em;
   transform: rotate(-2deg);
 }
 
@@ -1153,8 +1198,8 @@ h1 em {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: .15rem .5rem;
-  padding-bottom: .42rem;
-  font-size: .68rem;
+  padding-bottom: .52rem;
+  font-size: .7rem;
   font-weight: 800;
 }
 
@@ -1228,7 +1273,7 @@ h1 em {
 .slowmo .comic-grain { opacity: .3; mix-blend-mode: overlay; }
 .turning .speed-lines { opacity: .75; }
 
-@media (max-width: 840px) {
+@media (max-width: 979px) {
   .start-overlay {
     display: flex;
     justify-content: flex-start;
@@ -1236,24 +1281,157 @@ h1 em {
     padding: 0;
   }
 
+  .start-layout {
+    display: block;
+    width: 100%;
+    min-height: 100dvh;
+  }
+
   .title-panel {
     width: 100%;
     min-height: 100dvh;
+    padding: max(1.25rem, var(--safe-top)) max(1.25rem, var(--safe-right)) max(1.25rem, var(--safe-bottom)) max(1.25rem, var(--safe-left));
     border-width: 0;
     box-shadow: none;
     transform: none;
   }
 
-  .mascot-stage { right: -10%; bottom: 12%; width: 75%; }
-  .start-footer { bottom: calc(var(--safe-bottom) + .5rem); }
-  .mission-board { position: static; width: min(340px, 88vw); margin: 1.4rem auto 7.5rem; transform: none; }
-  #game-shell:not(.running) .close-button { top: auto; bottom: var(--safe-bottom); }
+  .mascot-stage { right: -8%; bottom: 13%; width: min(70%, 500px); }
+
+  .start-footer {
+    left: max(1.25rem, var(--safe-left));
+    bottom: calc(var(--safe-bottom) + 5.2rem);
+    gap: .62rem;
+  }
+
+  .start-secondary-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .start-sidebar {
+    position: absolute;
+    z-index: 6;
+    left: max(1.25rem, var(--safe-left));
+    right: max(1.25rem, var(--safe-right));
+    bottom: var(--safe-bottom);
+    grid-template-columns: 1fr 1fr;
+    gap: .7rem;
+    width: auto;
+  }
+
+  .sidebar-card,
+  .skin-sidebar,
+  .mission-board {
+    position: static;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+  }
+
+  .sidebar-toggle {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    width: 100%;
+    min-height: 3.55rem;
+    padding: .58rem .7rem;
+    border: 3px solid var(--ink);
+    color: var(--ink);
+    background: var(--cream);
+    box-shadow: 4px 4px 0 var(--ink);
+    cursor: pointer;
+    text-align: left;
+    transition: transform .16s ease, box-shadow .16s ease, background .16s ease;
+  }
+
+  .sidebar-toggle:hover { transform: translate(-1px, -1px); box-shadow: 5px 5px 0 var(--ink); }
+  .sidebar-toggle:active { transform: translate(2px, 2px); box-shadow: 1px 1px 0 var(--ink); }
+
+  .sidebar-toggle span,
+  .sidebar-toggle strong {
+    display: block;
+    grid-column: 1;
+    white-space: nowrap;
+  }
+
+  .sidebar-toggle span {
+    font-family: var(--display);
+    font-size: .68rem;
+    letter-spacing: .02em;
+  }
+
+  .sidebar-toggle strong {
+    margin-top: .12rem;
+    font-size: .63rem;
+    line-height: 1.1;
+  }
+
+  .sidebar-toggle b {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    align-self: center;
+    font-family: var(--display);
+    font-size: 1.2rem;
+    line-height: 1;
+    transition: transform .18s ease;
+  }
+
+  .sidebar-toggle[aria-expanded="true"] {
+    background: var(--sun);
+  }
+
+  .sidebar-toggle[aria-expanded="true"] b { transform: rotate(45deg); }
+
+  .sidebar-panel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(100% + .75rem);
+    display: none;
+    max-height: min(54dvh, 420px);
+    overflow: auto;
+    padding: 1rem;
+    background: var(--cream);
+    border: 4px solid var(--ink);
+    box-shadow: 7px 7px 0 var(--ink), -4px 4px 0 var(--stage-accent);
+  }
+
+  .sidebar-panel.is-expanded {
+    display: block;
+    animation: sidebarPanelIn .2s cubic-bezier(.16, 1, .3, 1) both;
+  }
+
+  .sidebar-title { margin-bottom: .75rem; }
+  .skin-picker { grid-template-columns: 1fr 1fr; }
+  .mission-board-title { margin-top: 0; }
+
+  #game-shell:not(.running) .close-button {
+    top: var(--safe-top);
+    right: var(--safe-right);
+    bottom: auto;
+  }
+
+  #game-shell:not(.running) > .music-button {
+    top: var(--safe-top);
+    right: calc(var(--safe-right) + 3.2rem);
+    bottom: auto;
+    left: auto;
+  }
 
   .controls-overlay { place-items: start center; padding: 0; }
   .controls-card { width: 100%; min-height: 100dvh; border: 0; box-shadow: none; transform: none; }
   .controls-card { max-height: 100dvh; overflow: auto; }
   .control-guide { grid-template-columns: 1fr; }
   .control-guide article { min-height: auto; }
+}
+
+@keyframes sidebarPanelIn {
+  from { opacity: 0; transform: translateY(8px) scale(.985); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 @media (max-width: 600px) {
@@ -1288,8 +1466,17 @@ h1 em {
   .icon-button { width: 2.45rem; border-width: 2px; box-shadow: 3px 3px 0 var(--ink); }
   .turn-prompt { top: 20%; min-width: 80vw; }
   .threat-warning { top: 30%; }
-  h1 { font-size: clamp(3.55rem, 20vw, 5.5rem); }
+  h1 { font-size: clamp(3.35rem, 17vw, 4.8rem); }
   .title-deck { max-width: 24ch; }
+  .mascot-stage { right: -16%; bottom: 14%; width: 82%; }
+  .burst-one { display: none; }
+  .comic-button span { padding: .88rem 1rem; }
+  .comic-button b { min-width: 3rem; }
+  .start-secondary-row { gap: .8rem; }
+  .best-line { font-size: .68rem; }
+  .sidebar-toggle { min-height: 3.35rem; padding: .5rem .58rem; }
+  .sidebar-toggle span { font-size: .62rem; }
+  .sidebar-toggle strong { font-size: .58rem; }
   .result-grid { grid-template-columns: 1fr 1fr 1fr; }
   .stage-banner { top: 27%; min-width: 86vw; }
   .controls-card h2 { font-size: 3.7rem; }

--- a/public/junglerun/cappy-3d.js
+++ b/public/junglerun/cappy-3d.js
@@ -114,6 +114,11 @@
     missionList: document.getElementById('mission-list'),
     musicButton: document.getElementById('music-button'),
     skinOptions: Array.prototype.slice.call(document.querySelectorAll('.skin-option')),
+    skinMenuToggle: document.getElementById('skin-menu-toggle'),
+    skinMenuPanel: document.getElementById('skin-menu-panel'),
+    selectedSkinName: document.getElementById('selected-skin-name'),
+    missionMenuToggle: document.getElementById('mission-menu-toggle'),
+    missionMenuPanel: document.getElementById('mission-menu-panel'),
     boostMeter: document.getElementById('boost-meter'),
     boostFill: document.getElementById('boost-fill'),
     boostValue: document.getElementById('boost-value'),
@@ -626,7 +631,7 @@
       texture.magFilter = THREE.LinearFilter;
       return texture;
     } catch (error) {
-      // Canvas may be tainted when served from file:// — fall back to classic.
+      // Canvas may be tainted when served from file://, so fall back to classic.
       return sourceTexture;
     }
   }
@@ -640,7 +645,27 @@
       button.setAttribute('aria-checked', String(button.dataset.skin === skin));
       button.classList.toggle('selected', button.dataset.skin === skin);
     });
+    dom.selectedSkinName.textContent = skin === 'ink' ? 'Comic Ink' : 'Classic';
     if (player.art) setPlayerPose(player.currentPose, true);
+  }
+
+  function setStartMenu(toggle, panel, expanded) {
+    toggle.setAttribute('aria-expanded', String(expanded));
+    panel.classList.toggle('is-expanded', expanded);
+  }
+
+  function closeStartMenus() {
+    const hadOpenMenu = dom.skinMenuToggle.getAttribute('aria-expanded') === 'true'
+      || dom.missionMenuToggle.getAttribute('aria-expanded') === 'true';
+    setStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, false);
+    setStartMenu(dom.missionMenuToggle, dom.missionMenuPanel, false);
+    return hadOpenMenu;
+  }
+
+  function toggleStartMenu(toggle, panel, otherToggle, otherPanel) {
+    const shouldOpen = toggle.getAttribute('aria-expanded') !== 'true';
+    setStartMenu(otherToggle, otherPanel, false);
+    setStartMenu(toggle, panel, shouldOpen);
   }
 
   function resetSegments(safeStart) {
@@ -2438,6 +2463,7 @@
         }
         return;
       }
+      if (key === 'escape' && state.mode === GAME.START && closeStartMenus()) return;
       if (key === '?') {
         openControls();
         return;
@@ -2640,8 +2666,17 @@
       initAudio();
       toggleMusic();
     });
+    dom.skinMenuToggle.addEventListener('click', function () {
+      toggleStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, dom.missionMenuToggle, dom.missionMenuPanel);
+    });
+    dom.missionMenuToggle.addEventListener('click', function () {
+      toggleStartMenu(dom.missionMenuToggle, dom.missionMenuPanel, dom.skinMenuToggle, dom.skinMenuPanel);
+    });
     dom.skinOptions.forEach(function (button) {
-      button.addEventListener('click', function () { applySkin(button.dataset.skin); });
+      button.addEventListener('click', function () {
+        applySkin(button.dataset.skin);
+        if (window.matchMedia('(max-width: 979px)').matches) setStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, false);
+      });
     });
   }
 

--- a/public/junglerun/index.html
+++ b/public/junglerun/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#102a22">
-  <meta name="description" content="Cappy Jungle Run — a comic-book 3D endless runner. Sprint from jungle to hot springs, crystal caves and a neon city with the CloseDose capybara mascot.">
+  <meta name="description" content="Cappy Jungle Run, a comic-book 3D endless runner. Sprint from jungle to hot springs, crystal caves and a neon city with the CloseDose capybara mascot.">
   <title>Cappy Jungle Run</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -83,34 +83,57 @@
     <button id="close-game-btn" class="icon-button close-button" type="button" aria-label="Exit game">×</button>
 
     <section id="start-screen" class="overlay start-overlay" aria-labelledby="game-title">
-      <div class="title-panel">
-        <p class="issue-label">Cappy No. 01 · Amazon Run</p>
-        <h1 id="game-title"><span>CAPPY</span><em>JUNGLE</em><span>RUN</span></h1>
-        <p class="title-deck">Three lanes. Wild turns. One very determined capybara.</p>
+      <div class="start-layout">
+        <div class="title-panel">
+          <p class="issue-label">Cappy No. 01 · Amazon Run</p>
+          <h1 id="game-title"><span>CAPPY</span><em>JUNGLE</em><span>RUN</span></h1>
+          <p class="title-deck">Three lanes. Wild turns. One very determined capybara.</p>
 
-        <div class="mascot-stage" aria-hidden="true">
-          <span class="burst-word burst-one">ZIP!</span>
-          <span class="burst-word burst-two">GO!</span>
-          <img src="assets/cappy-full-body.png" alt="" draggable="false">
-          <span class="mascot-shadow"></span>
-        </div>
-
-        <div class="start-footer">
-          <div class="skin-picker" role="radiogroup" aria-label="Choose Cappy's look">
-            <span class="skin-label">SKIN</span>
-            <button class="skin-option" type="button" data-skin="classic" role="radio" aria-checked="true">CLASSIC</button>
-            <button class="skin-option" type="button" data-skin="ink" role="radio" aria-checked="false">COMIC INK</button>
+          <div class="mascot-stage" aria-hidden="true">
+            <span class="burst-word burst-one">ZIP!</span>
+            <span class="burst-word burst-two">GO!</span>
+            <img src="assets/cappy-full-body.png" alt="" draggable="false">
+            <span class="mascot-shadow"></span>
           </div>
-          <button id="start-button" class="comic-button" type="button">
-            <span>START RUN</span><b>→</b>
-          </button>
-          <button id="start-help-button" class="text-button help-text-button" type="button">How to run</button>
-          <div class="best-line">Best score <strong id="start-highscore">00000</strong></div>
+
+          <div class="start-footer">
+            <button id="start-button" class="comic-button" type="button">
+              <span>START RUN</span><b>→</b>
+            </button>
+            <div class="start-secondary-row">
+              <button id="start-help-button" class="text-button help-text-button" type="button">How to run</button>
+              <div class="best-line">Best score <strong id="start-highscore">00000</strong></div>
+            </div>
+          </div>
         </div>
 
-        <aside class="mission-board" aria-label="Missions">
-          <span class="mission-board-title">MISSIONS</span>
-          <ul id="mission-list"></ul>
+        <aside class="start-sidebar" aria-label="Customize your run">
+          <section class="sidebar-card skin-sidebar">
+            <button id="skin-menu-toggle" class="sidebar-toggle" type="button" aria-expanded="false" aria-controls="skin-menu-panel">
+              <span>Choose skin</span>
+              <strong id="selected-skin-name">Classic</strong>
+              <b aria-hidden="true">+</b>
+            </button>
+            <div id="skin-menu-panel" class="sidebar-panel skin-menu-panel">
+              <h2 class="sidebar-title">SKINS</h2>
+              <div class="skin-picker" role="radiogroup" aria-label="Choose Cappy's look">
+                <button class="skin-option" type="button" data-skin="classic" role="radio" aria-checked="true">CLASSIC</button>
+                <button class="skin-option" type="button" data-skin="ink" role="radio" aria-checked="false">COMIC INK</button>
+              </div>
+            </div>
+          </section>
+
+          <section class="sidebar-card mission-board" aria-label="Missions">
+            <button id="mission-menu-toggle" class="sidebar-toggle" type="button" aria-expanded="false" aria-controls="mission-menu-panel">
+              <span>Missions</span>
+              <strong>View progress</strong>
+              <b aria-hidden="true">+</b>
+            </button>
+            <div id="mission-menu-panel" class="sidebar-panel mission-menu-panel">
+              <h2 class="sidebar-title mission-board-title">MISSIONS</h2>
+              <ul id="mission-list"></ul>
+            </div>
+          </section>
         </aside>
       </div>
     </section>
@@ -131,7 +154,7 @@
             <span class="guide-number">02</span>
             <div class="guide-keys"><kbd>↑</kbd><kbd>↓</kbd><b>or swipe</b></div>
             <strong>Jump / slide</strong>
-            <p>Jump logs, pits and gorge gaps. Slide beneath vines, low branches and temple bars. Watch for ↑ and ↓ signs — they call the move.</p>
+            <p>Jump logs, pits and gorge gaps. Slide beneath vines, low branches and temple bars. The ↑ and ↓ signs call the move.</p>
           </article>
           <article class="boost-guide">
             <span class="guide-number">03</span>


### PR DESCRIPTION
## What changed

- Reworked the Jungle Run start screen into a spacious main cover plus a desktop utility sidebar.
- Moved skins and missions into the sidebar at widths of 980px and above.
- Added compact mobile skin and mission disclosure buttons with mutually exclusive expandable panels.
- Kept skin selection synchronized with the mascot and added Escape-key dismissal.
- Adjusted mobile spacing so the title, mascot, primary action, score, and utility controls no longer compete for the same space.

## Why

The previous mobile layout placed the mission board in the middle of the start screen and crowded the skin picker, CTA, score, and mascot together near the bottom. Wide screens also left enough unused space for missions and skins to live outside the main cover.

## Impact

Players get a clearer landing screen on desktop and mobile without changing gameplay, routes, saved progress, or existing game controls.

## Validation

- `node --check public/junglerun/cappy-3d.js`
- `git diff --check`
- All 60 JavaScript-required DOM IDs present with no duplicates
- All local HTML asset references present
- Desktop and mobile responsive browser checks with no horizontal overflow
- Skin selection and mission disclosure interaction tests
- Start Run smoke test reached `RUNNING` with one canvas and visible HUD
- Zero browser errors or warnings