### PR TITLE
Improve Jungle Run mobile landing and skins

### DIFF
--- a/public/junglerun/cappy-3d.css
+++ b/public/junglerun/cappy-3d.css
@@ -13,6 +13,7 @@
   --shadow: #081a15;
   --display: "Archivo Black", Impact, sans-serif;
   --body: "DM Sans", system-ui, sans-serif;
+  --app-height: 100vh;
   --safe-top: max(18px, env(safe-area-inset-top));
   --safe-right: max(18px, env(safe-area-inset-right));
   --safe-bottom: max(18px, env(safe-area-inset-bottom));
@@ -644,6 +645,7 @@ a:focus-visible {
 
 .start-overlay {
   padding: clamp(1rem, 3vw, 2.5rem);
+  overscroll-behavior: contain;
 }
 
 .start-layout {
@@ -760,6 +762,7 @@ h1 em {
   object-fit: contain;
   filter: drop-shadow(5px 6px 0 var(--ink));
   transform-origin: center bottom;
+  transition: filter .28s cubic-bezier(.16, 1, .3, 1);
   animation: mascotBounce 1s steps(2) infinite;
 }
 
@@ -1100,13 +1103,13 @@ h1 em {
 
 .skin-picker {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: .65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .45rem;
 }
 
 .skin-option {
   min-height: 3rem;
-  padding: .65rem .8rem;
+  padding: .65rem .35rem;
   border: 3px solid var(--ink);
   background: var(--paper);
   box-shadow: 3px 3px 0 var(--ink);
@@ -1126,14 +1129,30 @@ h1 em {
   box-shadow: 3px 3px 0 var(--coral);
 }
 
-.skin-option[data-skin="ink"] {
+.skin-option[data-skin="mono"] {
   background-image: radial-gradient(rgba(20,37,31,.32) 1px, transparent 1.2px);
   background-size: 6px 6px;
 }
 
-.skin-option[data-skin="ink"].selected { background-image: radial-gradient(rgba(245,234,213,.4) 1px, transparent 1.2px); }
+.skin-option[data-skin="mono"].selected { background-image: radial-gradient(rgba(245,234,213,.4) 1px, transparent 1.2px); }
 
-.skin-ink .mascot-stage img { filter: grayscale(1) contrast(1.45) brightness(1.06); }
+.skin-option[data-skin="river"] {
+  background: var(--river);
+}
+
+.skin-option[data-skin="river"].selected {
+  color: var(--cream);
+  background: var(--leaf);
+  box-shadow: 3px 3px 0 var(--river);
+}
+
+.skin-mono .mascot-stage img {
+  filter: grayscale(1) contrast(1.45) brightness(1.06) drop-shadow(5px 6px 0 var(--ink));
+}
+
+.skin-river .mascot-stage img {
+  filter: sepia(.85) saturate(1.35) hue-rotate(118deg) brightness(1.04) contrast(1.08) drop-shadow(5px 6px 0 var(--ink));
+}
 
 .start-sidebar {
   position: relative;
@@ -1219,6 +1238,11 @@ h1 em {
 
 .mission-complete-all { font-family: var(--display); font-size: .64rem; }
 
+.mission-menu-close,
+.mission-modal-backdrop {
+  display: none;
+}
+
 .power-chip { font-size: .72rem; letter-spacing: .05em; }
 .magnet-chip { background: var(--coral); }
 .star-chip { background: var(--sun); color: var(--ink); }
@@ -1278,25 +1302,30 @@ h1 em {
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    height: var(--app-height);
+    min-height: 0;
     padding: 0;
+    overflow: hidden;
   }
 
   .start-layout {
     display: block;
     width: 100%;
-    min-height: 100dvh;
+    height: var(--app-height);
+    min-height: 0;
   }
 
   .title-panel {
     width: 100%;
-    min-height: 100dvh;
+    height: 100%;
+    min-height: 0;
     padding: max(1.25rem, var(--safe-top)) max(1.25rem, var(--safe-right)) max(1.25rem, var(--safe-bottom)) max(1.25rem, var(--safe-left));
     border-width: 0;
     box-shadow: none;
     transform: none;
   }
 
-  .mascot-stage { right: -8%; bottom: 13%; width: min(70%, 500px); }
+  .mascot-stage { right: -4%; bottom: 14%; width: min(64%, 440px); }
 
   .start-footer {
     left: max(1.25rem, var(--safe-left));
@@ -1312,7 +1341,7 @@ h1 em {
 
   .start-sidebar {
     position: absolute;
-    z-index: 6;
+    z-index: auto;
     left: max(1.25rem, var(--safe-left));
     right: max(1.25rem, var(--safe-right));
     bottom: var(--safe-bottom);
@@ -1400,14 +1429,79 @@ h1 em {
     box-shadow: 7px 7px 0 var(--ink), -4px 4px 0 var(--stage-accent);
   }
 
+  .skin-menu-panel {
+    z-index: 7;
+  }
+
   .sidebar-panel.is-expanded {
     display: block;
     animation: sidebarPanelIn .2s cubic-bezier(.16, 1, .3, 1) both;
   }
 
   .sidebar-title { margin-bottom: .75rem; }
-  .skin-picker { grid-template-columns: 1fr 1fr; }
+  .skin-picker { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .mission-board-title { margin-top: 0; }
+
+  .mission-modal-backdrop {
+    position: fixed;
+    z-index: 8;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: var(--app-height);
+    border: 0;
+    background: rgba(8, 26, 21, .68);
+    backdrop-filter: blur(5px) saturate(.72);
+    -webkit-backdrop-filter: blur(5px) saturate(.72);
+    cursor: pointer;
+  }
+
+  .mission-menu-panel {
+    position: fixed;
+    z-index: 9;
+    top: 50%;
+    right: max(1rem, var(--safe-right));
+    bottom: auto;
+    left: max(1rem, var(--safe-left));
+    width: auto;
+    max-height: calc(var(--app-height) - var(--safe-top) - var(--safe-bottom) - 2rem);
+    overflow: hidden;
+    padding: 1.15rem;
+    transform: translateY(-50%);
+    box-shadow: 9px 9px 0 var(--ink), -5px 5px 0 var(--river);
+  }
+
+  .mission-menu-panel.is-expanded {
+    display: block;
+    animation: missionModalIn .24s cubic-bezier(.16, 1, .3, 1) both;
+  }
+
+  .mission-menu-close {
+    position: absolute;
+    top: .7rem;
+    right: .7rem;
+    display: grid;
+    place-items: center;
+    width: 2.55rem;
+    aspect-ratio: 1;
+    border: 3px solid var(--ink);
+    color: var(--cream);
+    background: var(--leaf);
+    box-shadow: 3px 3px 0 var(--ink);
+    font-family: var(--display);
+    font-size: 1.15rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .mission-menu-close:active {
+    transform: translate(2px, 2px);
+    box-shadow: 1px 1px 0 var(--ink);
+  }
+
+  .mission-menu-panel .mission-board-title {
+    margin-right: 3.25rem;
+  }
 
   #game-shell:not(.running) .close-button {
     top: var(--safe-top);
@@ -1427,6 +1521,11 @@ h1 em {
   .controls-card { max-height: 100dvh; overflow: auto; }
   .control-guide { grid-template-columns: 1fr; }
   .control-guide article { min-height: auto; }
+}
+
+@keyframes missionModalIn {
+  from { opacity: 0; transform: translateY(calc(-50% + 12px)) scale(.97); }
+  to { opacity: 1; transform: translateY(-50%) scale(1); }
 }
 
 @keyframes sidebarPanelIn {
@@ -1466,9 +1565,9 @@ h1 em {
   .icon-button { width: 2.45rem; border-width: 2px; box-shadow: 3px 3px 0 var(--ink); }
   .turn-prompt { top: 20%; min-width: 80vw; }
   .threat-warning { top: 30%; }
-  h1 { font-size: clamp(3.35rem, 17vw, 4.8rem); }
-  .title-deck { max-width: 24ch; }
-  .mascot-stage { right: -16%; bottom: 14%; width: 82%; }
+  h1 { font-size: clamp(3rem, 14.2vw, 4.35rem); }
+  .title-deck { max-width: 25ch; font-size: .9rem; }
+  .mascot-stage { right: -7%; bottom: 16%; width: 76%; }
   .burst-one { display: none; }
   .comic-button span { padding: .88rem 1rem; }
   .comic-button b { min-width: 3rem; }
@@ -1482,11 +1581,43 @@ h1 em {
   .controls-card h2 { font-size: 3.7rem; }
 }
 
+@media (max-width: 430px) and (max-height: 720px) {
+  .title-panel {
+    padding-top: max(.85rem, var(--safe-top));
+  }
+
+  .issue-label { font-size: .64rem; }
+  h1 { margin-top: .45rem; font-size: clamp(2.8rem, 13.6vw, 3.7rem); }
+  .title-deck { margin-top: .7rem; font-size: .82rem; }
+  .mascot-stage { right: -4%; bottom: 16%; width: 70%; }
+  .start-footer { bottom: calc(var(--safe-bottom) + 4.65rem); gap: .5rem; }
+  .start-secondary-row { gap: .65rem; }
+  .burst-two { display: none; }
+}
+
+@media (max-width: 979px) and (max-height: 520px) {
+  .title-panel {
+    padding-top: max(.75rem, var(--safe-top));
+  }
+
+  .issue-label { max-width: 42%; font-size: .58rem; }
+  h1 { margin-top: .35rem; font-size: clamp(2.25rem, 8vw, 3.4rem); }
+  .title-deck { display: none; }
+  .mascot-stage { right: 1%; bottom: 17%; width: min(46%, 280px); }
+  .start-footer { left: 43%; bottom: calc(var(--safe-bottom) + 4.35rem); gap: .42rem; }
+  .start-secondary-row { gap: .55rem; }
+  .comic-button span { padding: .72rem .85rem; font-size: .82rem; }
+  .comic-button b { min-width: 2.7rem; }
+  .best-line { font-size: .6rem; }
+  .help-text-button { font-size: .68rem; }
+  .burst-word { display: none; }
+}
+
 @keyframes superchargePulseMobile {
   50% { transform: rotate(-1deg) scale(1.035); box-shadow: 6px 6px 0 var(--stage-accent), -4px 4px 0 var(--coral); }
 }
 
-@media (max-height: 690px) and (min-width: 700px) {
+@media (max-height: 690px) and (min-width: 980px) {
   .title-panel { min-height: 90vh; }
   h1 { font-size: clamp(3.6rem, 9vw, 6.2rem); }
   .mascot-stage { width: 55%; }

--- a/public/junglerun/cappy-3d.js
+++ b/public/junglerun/cappy-3d.js
@@ -114,11 +114,14 @@
     missionList: document.getElementById('mission-list'),
     musicButton: document.getElementById('music-button'),
     skinOptions: Array.prototype.slice.call(document.querySelectorAll('.skin-option')),
+    landingMascot: document.getElementById('landing-mascot'),
     skinMenuToggle: document.getElementById('skin-menu-toggle'),
     skinMenuPanel: document.getElementById('skin-menu-panel'),
     selectedSkinName: document.getElementById('selected-skin-name'),
     missionMenuToggle: document.getElementById('mission-menu-toggle'),
     missionMenuPanel: document.getElementById('mission-menu-panel'),
+    missionMenuClose: document.getElementById('mission-menu-close'),
+    missionModalBackdrop: document.getElementById('mission-modal-backdrop'),
     boostMeter: document.getElementById('boost-meter'),
     boostFill: document.getElementById('boost-fill'),
     boostValue: document.getElementById('boost-value'),
@@ -216,7 +219,8 @@
     coral: null,
     afterimages: [],
     poseTextures: {},
-    inkTextures: {},
+    monoTextures: {},
+    riverTextures: {},
     skin: 'classic',
     currentPose: 'runA',
     shadow: null,
@@ -277,9 +281,11 @@
     renderMissions();
     applySkin(safeReadString('cappy_skin', 'classic'));
     syncMusicButton();
+    resize();
 
     window.addEventListener('resize', resize, { passive: true });
     window.addEventListener('orientationchange', resize, { passive: true });
+    if (window.visualViewport) window.visualViewport.addEventListener('resize', resize, { passive: true });
     document.addEventListener('visibilitychange', function () {
       if (document.hidden && state.mode === GAME.RUNNING) pauseGame();
     });
@@ -594,17 +600,23 @@
   }
 
   function getSkinTexture(name) {
-    if (player.skin === 'ink') {
-      if (!player.inkTextures[name] && player.poseTextures[name]) {
-        player.inkTextures[name] = makeInkTexture(player.poseTextures[name]);
+    if (player.skin === 'mono') {
+      if (!player.monoTextures[name] && player.poseTextures[name]) {
+        player.monoTextures[name] = makeMonoTexture(player.poseTextures[name]);
       }
-      return player.inkTextures[name] || player.poseTextures[name];
+      return player.monoTextures[name] || player.poseTextures[name];
+    }
+    if (player.skin === 'river') {
+      if (!player.riverTextures[name] && player.poseTextures[name]) {
+        player.riverTextures[name] = makeRiverTexture(player.poseTextures[name]);
+      }
+      return player.riverTextures[name] || player.poseTextures[name];
     }
     return player.poseTextures[name];
   }
 
   // Newsprint b&w with a screentone dot pattern, generated from the classic art.
-  function makeInkTexture(sourceTexture) {
+  function makeMonoTexture(sourceTexture) {
     try {
       const image = sourceTexture.image;
       const canvas = document.createElement('canvas');
@@ -636,29 +648,92 @@
     }
   }
 
+  // Recolors Cappy's warm fur into the cool river palette while preserving neutral facial details.
+  function makeRiverTexture(sourceTexture) {
+    try {
+      const image = sourceTexture.image;
+      const canvas = document.createElement('canvas');
+      canvas.width = image.width;
+      canvas.height = image.height;
+      const context = canvas.getContext('2d');
+      context.drawImage(image, 0, 0);
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      const px = imageData.data;
+      for (let i = 0; i < px.length; i += 4) {
+        if (px[i + 3] < 8) continue;
+        const red = px[i];
+        const green = px[i + 1];
+        const blue = px[i + 2];
+        const warm = red > blue * 1.12 && green > blue * .82 && red > green * 1.02;
+        if (!warm) continue;
+        const light = Math.max(0, Math.min(1, (red * .3 + green * .59 + blue * .11) / 255));
+        const riverRed = 24 + 114 * light;
+        const riverGreen = 75 + 138 * light;
+        const riverBlue = 72 + 137 * light;
+        px[i] = red * .18 + riverRed * .82;
+        px[i + 1] = green * .18 + riverGreen * .82;
+        px[i + 2] = blue * .18 + riverBlue * .82;
+      }
+      context.putImageData(imageData, 0, 0);
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.encoding = THREE.sRGBEncoding;
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      return texture;
+    } catch (error) {
+      return sourceTexture;
+    }
+  }
+
   function applySkin(name) {
-    const skin = name === 'ink' ? 'ink' : 'classic';
+    const skin = name === 'river' ? 'river' : ((name === 'mono' || name === 'ink') ? 'mono' : 'classic');
+    const skinLabels = { classic: 'Classic', mono: 'Mono', river: 'River' };
     player.skin = skin;
     safeWriteString('cappy_skin', skin);
-    dom.shell.classList.toggle('skin-ink', skin === 'ink');
+    dom.shell.classList.toggle('skin-mono', skin === 'mono');
+    dom.shell.classList.toggle('skin-river', skin === 'river');
     dom.skinOptions.forEach(function (button) {
       button.setAttribute('aria-checked', String(button.dataset.skin === skin));
       button.classList.toggle('selected', button.dataset.skin === skin);
     });
-    dom.selectedSkinName.textContent = skin === 'ink' ? 'Comic Ink' : 'Classic';
+    dom.selectedSkinName.textContent = skinLabels[skin];
+    if (dom.landingMascot) dom.landingMascot.alt = 'Cappy in the ' + skinLabels[skin] + ' skin';
     if (player.art) setPlayerPose(player.currentPose, true);
+  }
+
+  function usesMobileStartMenus() {
+    return window.matchMedia('(max-width: 979px)').matches;
+  }
+
+  function syncMissionModalPresentation(expanded) {
+    const modalOpen = expanded && usesMobileStartMenus();
+    dom.missionModalBackdrop.classList.toggle('hidden', !modalOpen);
+    dom.shell.classList.toggle('mission-modal-open', modalOpen);
+    if (modalOpen) {
+      dom.missionMenuPanel.setAttribute('role', 'dialog');
+      dom.missionMenuPanel.setAttribute('aria-modal', 'true');
+      dom.missionMenuPanel.setAttribute('aria-labelledby', 'mission-menu-title');
+    } else {
+      dom.missionMenuPanel.removeAttribute('role');
+      dom.missionMenuPanel.removeAttribute('aria-modal');
+      dom.missionMenuPanel.removeAttribute('aria-labelledby');
+    }
   }
 
   function setStartMenu(toggle, panel, expanded) {
     toggle.setAttribute('aria-expanded', String(expanded));
     panel.classList.toggle('is-expanded', expanded);
+    if (panel === dom.missionMenuPanel) syncMissionModalPresentation(expanded);
   }
 
   function closeStartMenus() {
-    const hadOpenMenu = dom.skinMenuToggle.getAttribute('aria-expanded') === 'true'
-      || dom.missionMenuToggle.getAttribute('aria-expanded') === 'true';
+    const skinWasOpen = dom.skinMenuToggle.getAttribute('aria-expanded') === 'true';
+    const missionWasOpen = dom.missionMenuToggle.getAttribute('aria-expanded') === 'true';
+    const hadOpenMenu = skinWasOpen || missionWasOpen;
     setStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, false);
     setStartMenu(dom.missionMenuToggle, dom.missionMenuPanel, false);
+    const focusTarget = missionWasOpen ? dom.missionMenuToggle : (skinWasOpen ? dom.skinMenuToggle : null);
+    if (focusTarget) window.setTimeout(function () { focusTarget.focus(); }, 0);
     return hadOpenMenu;
   }
 
@@ -666,6 +741,7 @@
     const shouldOpen = toggle.getAttribute('aria-expanded') !== 'true';
     setStartMenu(otherToggle, otherPanel, false);
     setStartMenu(toggle, panel, shouldOpen);
+    return shouldOpen;
   }
 
   function resetSegments(safeStart) {
@@ -2455,6 +2531,16 @@
     document.addEventListener('keydown', function (event) {
       const key = event.key.toLowerCase();
       if (['arrowleft', 'arrowright', 'arrowup', 'arrowdown', ' ', 'a', 'b', 'd', 'w', 's', 'x', 'shift', '?'].includes(key)) event.preventDefault();
+      const missionModalOpen = usesMobileStartMenus()
+        && dom.missionMenuToggle.getAttribute('aria-expanded') === 'true';
+      if (missionModalOpen) {
+        if (key === 'escape') closeStartMenus();
+        else if (key === 'tab') {
+          event.preventDefault();
+          dom.missionMenuClose.focus();
+        }
+        return;
+      }
       if (!dom.controlsScreen.classList.contains('hidden')) {
         if (key === 'escape') closeControls();
         else if (key === 'tab') {
@@ -2670,12 +2756,15 @@
       toggleStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, dom.missionMenuToggle, dom.missionMenuPanel);
     });
     dom.missionMenuToggle.addEventListener('click', function () {
-      toggleStartMenu(dom.missionMenuToggle, dom.missionMenuPanel, dom.skinMenuToggle, dom.skinMenuPanel);
+      const opened = toggleStartMenu(dom.missionMenuToggle, dom.missionMenuPanel, dom.skinMenuToggle, dom.skinMenuPanel);
+      if (opened && usesMobileStartMenus()) window.setTimeout(function () { dom.missionMenuClose.focus(); }, 0);
     });
+    dom.missionMenuClose.addEventListener('click', closeStartMenus);
+    dom.missionModalBackdrop.addEventListener('click', closeStartMenus);
     dom.skinOptions.forEach(function (button) {
       button.addEventListener('click', function () {
         applySkin(button.dataset.skin);
-        if (window.matchMedia('(max-width: 979px)').matches) setStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, false);
+        if (usesMobileStartMenus()) setStartMenu(dom.skinMenuToggle, dom.skinMenuPanel, false);
       });
     });
   }
@@ -3195,6 +3284,9 @@
   }
 
   function resize() {
+    const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+    document.documentElement.style.setProperty('--app-height', Math.round(viewportHeight) + 'px');
+    if (dom.missionMenuToggle.getAttribute('aria-expanded') === 'true') syncMissionModalPresentation(true);
     if (!camera || !renderer) return;
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.fov = window.innerWidth < 600 ? 67 : 58;

--- a/public/junglerun/index.html
+++ b/public/junglerun/index.html
@@ -89,11 +89,11 @@
           <h1 id="game-title"><span>CAPPY</span><em>JUNGLE</em><span>RUN</span></h1>
           <p class="title-deck">Three lanes. Wild turns. One very determined capybara.</p>
 
-          <div class="mascot-stage" aria-hidden="true">
-            <span class="burst-word burst-one">ZIP!</span>
-            <span class="burst-word burst-two">GO!</span>
-            <img src="assets/cappy-full-body.png" alt="" draggable="false">
-            <span class="mascot-shadow"></span>
+          <div class="mascot-stage">
+            <span class="burst-word burst-one" aria-hidden="true">ZIP!</span>
+            <span class="burst-word burst-two" aria-hidden="true">GO!</span>
+            <img id="landing-mascot" src="assets/cappy-full-body.png" alt="Cappy in the Classic skin" draggable="false">
+            <span class="mascot-shadow" aria-hidden="true"></span>
           </div>
 
           <div class="start-footer">
@@ -118,7 +118,8 @@
               <h2 class="sidebar-title">SKINS</h2>
               <div class="skin-picker" role="radiogroup" aria-label="Choose Cappy's look">
                 <button class="skin-option" type="button" data-skin="classic" role="radio" aria-checked="true">CLASSIC</button>
-                <button class="skin-option" type="button" data-skin="ink" role="radio" aria-checked="false">COMIC INK</button>
+                <button class="skin-option" type="button" data-skin="mono" role="radio" aria-checked="false">MONO</button>
+                <button class="skin-option" type="button" data-skin="river" role="radio" aria-checked="false">RIVER</button>
               </div>
             </div>
           </section>
@@ -130,12 +131,14 @@
               <b aria-hidden="true">+</b>
             </button>
             <div id="mission-menu-panel" class="sidebar-panel mission-menu-panel">
-              <h2 class="sidebar-title mission-board-title">MISSIONS</h2>
+              <button id="mission-menu-close" class="mission-menu-close" type="button" aria-label="Close missions">×</button>
+              <h2 id="mission-menu-title" class="sidebar-title mission-board-title">MISSIONS</h2>
               <ul id="mission-list"></ul>
             </div>
           </section>
         </aside>
       </div>
+      <button id="mission-modal-backdrop" class="mission-modal-backdrop hidden" type="button" aria-label="Close missions"></button>
     </section>
 
     <section id="controls-screen" class="overlay controls-overlay hidden" aria-labelledby="controls-title" aria-modal="true" role="dialog">
@@ -206,6 +209,6 @@
     <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
   </main>
 
-  <script src="cappy-3d.js?v=20260718-continuous-turns"></script>
+  <script src="cappy-3d.js?v=20260718-mobile-skins"></script>
 </body>
 </html>


### PR DESCRIPTION
## **User description**
## Summary

- repair the Jungle Run landing layout for mobile viewports and Safari visual viewport sizing
- rename Comic to Mono and add a River skin, with live landing mascot updates
- present Missions as a focused mobile modal so the game remains a single-screen experience

## Verification

- `node --check public/junglerun/cappy-3d.js`
- DOM ID and local asset contract validation
- iPhone-sized Playwright WebKit smoke test: Mono/River selection, Missions modal, zero page scroll, and RUNNING game state


___

## **CodeAnt-AI Description**
**Improve Jungle Run mobile landing, skins, and missions**

### What Changed
- The landing screen now fits mobile viewports more reliably, including Safari’s changing viewport size, so the start screen stays within the visible area.
- The skin picker now offers Classic, Mono, and River, and the landing mascot updates to match the selected skin.
- Missions now open as a centered mobile modal with a close button and backdrop tap-to-close, instead of using the regular sidebar panel on small screens.
- The missions panel now keeps focus and keyboard closing behavior in place when opened on mobile.

### Impact
`✅ Fewer cut-off start screens on phones`
`✅ Clearer skin selection on mobile`
`✅ Easier missions viewing on small screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
