### PR TITLE
Fix PREtendingMD Google popup CSP

### DIFF
--- a/md/DEPLOYMENT.md
+++ b/md/DEPLOYMENT.md
@@ -22,8 +22,10 @@ provider 404.
 
 `static/_headers` applies a strict local-only Content Security Policy to the
 portal, PIG, and RSI. Only `/PMD/*` detaches that policy and applies the exact
-Firebase Authentication, token, Firestore, and Auth-frame origins required by
-PREtendingMD. The PMD route also changes COOP to
+Firebase Authentication, token, Firestore, Auth-frame, and Google Auth helper
+origins required by PREtendingMD. The Google helper is limited to
+`https://apis.google.com`; analytics and arbitrary Google-hosted scripts remain
+blocked. The PMD route also changes COOP to
 `same-origin-allow-popups` for Google sign-in; the other routes retain
 `same-origin`. Inline scripts, external analytics, arbitrary frames, objects,
 base overrides, and form submissions are blocked.

--- a/md/static/_headers
+++ b/md/static/_headers
@@ -9,7 +9,7 @@
 
 /PMD/*
   ! Content-Security-Policy
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com; frame-src https://gen-lang-client-0217325418.firebaseapp.com; frame-ancestors 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; manifest-src 'self'; worker-src 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://apis.google.com; style-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com; frame-src https://gen-lang-client-0217325418.firebaseapp.com; frame-ancestors 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; manifest-src 'self'; worker-src 'self'
   ! Cross-Origin-Opener-Policy
   Cross-Origin-Opener-Policy: same-origin-allow-popups
 

--- a/md/tests/distribution-contract.test.mjs
+++ b/md/tests/distribution-contract.test.mjs
@@ -189,6 +189,10 @@ test('security headers keep runtime capabilities local and HTML revalidated', as
   assert.ok(pmdHeaders.has('! content-security-policy'));
   assert.ok(pmdHeaders.has('! cross-origin-opener-policy'));
   const pmdCsp = parseCsp(pmdHeaders.get('content-security-policy'));
+  assert.deepEqual(pmdCsp.get('script-src'), [
+    "'self'",
+    'https://apis.google.com'
+  ]);
   assert.deepEqual(pmdCsp.get('connect-src'), [
     "'self'",
     'https://identitytoolkit.googleapis.com',


### PR DESCRIPTION
## What changed

- allow the exact Google Auth helper origin required by Firebase popup sign-in on `/PMD/*`
- keep the exception isolated from the portal, PIG, and RSI routes
- add a distribution contract regression assertion and document the exception

## Why

Live browser verification found that the existing PMD CSP blocked `https://apis.google.com/js/api.js`, causing Firebase `auth/internal-error` before the Google popup opened.

## Verification

- npm audit: 0 vulnerabilities
- 4 workspace typechecks
- 42 source/unit tests
- 7 Firestore authorization tests
- production build and 5 distribution contracts
- 11 local Playwright smoke tests
- focused popup regression: popup opened, 0 failed requests, no internal error