### PR TITLE
Mute the light-mode ground to teal so surfaces read as surfaces

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -73,11 +73,14 @@
   --duration-slow: 0.4s;
 
   /* Semantic Theme Variables - Light defaults */
-  --page-bg: #f2f6f5;
+  /* A muted teal ground, not near-white: the white cards, inputs and dose
+     readouts carry the page, so the ground has to sit behind them rather
+     than compete. At ~1.3:1 against #fff every card reads as a surface. */
+  --page-bg: #d7e7e3;
   /* One soft teal glow anchored to the top of the document; the rest is
      flat --page-bg. Sized in px so it does not stretch on long pages. */
   --page-bg-image:
-    radial-gradient(120% 100% at 50% 0%, rgba(36, 166, 135, 0.14), rgba(36, 166, 135, 0) 70%);
+    radial-gradient(120% 100% at 50% 0%, rgba(36, 166, 135, 0.18), rgba(36, 166, 135, 0) 70%);
   --page-bg-size: 100% 760px;
   --page-bg-repeat: no-repeat;
   --page-bg-blend: normal;
@@ -99,9 +102,13 @@
   --hero-eyebrow-color: rgba(15, 44, 42, 0.72);
   --hero-sub-color: rgba(15, 44, 42, 0.78);
   --hero-shadow: none;
-  --on-bg-muted: rgba(15, 44, 42, 0.65);
-  --on-bg-link: var(--teal-500);
-  --menu-overlay-bg: rgba(245, 249, 249, 0.98);
+  /* Text and links sitting straight on --page-bg, not on a white card. The
+     teal ground is darker than the old near-white, so both go a step deeper
+     to hold 4.5:1: teal-500 only reaches 3.1:1 here. */
+  --on-bg-muted: rgba(15, 44, 42, 0.7);
+  --on-bg-link: #14705f;
+  --on-bg-link-hover: var(--teal-500);
+  --menu-overlay-bg: rgba(215, 231, 227, 0.98);
   --menu-link-color: var(--ink-900);
   --theme-toggle-bg: var(--white);
   --theme-toggle-icon: '🌙';
@@ -249,6 +256,7 @@ html[data-theme="dark"] {
   --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
   --on-bg-muted: rgba(255, 255, 255, 0.78);
   --on-bg-link: var(--teal-400);
+  --on-bg-link-hover: var(--footer-link);
   --menu-overlay-bg: rgba(15, 25, 23, 0.98);
   --menu-link-color: #e2e8f0;
   --theme-toggle-icon: '☀️';
@@ -588,6 +596,7 @@ html[data-theme="dark"] .cdcalc-title {
     --hero-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
     --on-bg-muted: rgba(255, 255, 255, 0.78);
     --on-bg-link: var(--teal-400);
+    --on-bg-link-hover: var(--footer-link);
     --menu-overlay-bg: rgba(15, 25, 23, 0.98);
     --menu-link-color: #e2e8f0;
     --theme-toggle-icon: '☀️';
@@ -1648,7 +1657,7 @@ html[data-theme="dark"] .donate-link--givebutter {
 .disclaimer-content p { margin: 0; }
 .disclaimer-seek-care { color: var(--danger); }
 .disclaimer-link {
-  color: var(--teal-500);
+  color: var(--on-bg-link);
   font-weight: 700;
   text-decoration: none;
 }
@@ -3664,7 +3673,7 @@ html[data-theme="dark"] .no-tare-btn { background: rgba(255, 200, 100, 0.07); }
   font-weight: 900;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--teal-500);
+  color: var(--on-bg-link);
   margin-bottom: 12px;
   display: block;
 }
@@ -3884,13 +3893,13 @@ html[data-theme="dark"] .big-metric {
 }
 
 .editorial-textlink {
-  color: var(--teal-500);
+  color: var(--on-bg-link);
   font-weight: 800;
   text-decoration: underline;
   transition: color var(--duration-fast);
 }
 .editorial-textlink:hover {
-  color: var(--teal-400);
+  color: var(--on-bg-link-hover);
 }
 
 /* Mail Envelope Animation */

--- a/public/legal/legal.css
+++ b/public/legal/legal.css
@@ -4,7 +4,9 @@
   --muted:#4A5A55;
   --surface:#ffffff;
   --border:#dfeee9;
-  --bg:#f6fbf8;
+  /* Matches the muted teal ground the rest of the site uses in light mode,
+     so following a footer link does not flash back to near-white. */
+  --bg:#d7e7e3;
   --max-width:880px;
   color-scheme: only light;
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone"],
   "theme_color": "#0f766e",
-  "background_color": "#ffffff",
+  "background_color": "#d7e7e3",
   "icons": [
     {
       "src": "images/favicon-192.png",

--- a/public/tools.registry.json
+++ b/public/tools.registry.json
@@ -6,6 +6,7 @@
     { "id": "allergy", "page": "allergy-calculator.html", "label": "Allergy Calculator" },
     { "id": "guides", "page": "medication-guides.html", "label": "Medication Guides" },
     { "id": "cough", "page": "cold-cough-guidance.html", "label": "Cough &amp; Cold Guidance" },
+    { "id": "breathing", "page": "infant-breathing/", "label": "Infant Breathing Guide" },
     { "id": "weighing", "page": "weighing-guide.html", "label": "Weighing Guide" },
     { "id": "dosing", "page": "dosing-guide.html", "label": "Dosing Guide" },
     { "id": "about", "page": "about.html", "label": "About" },

--- a/tests/parent-tools.test.mjs
+++ b/tests/parent-tools.test.mjs
@@ -52,9 +52,17 @@ test('rejects a registry that would produce a broken menu', () => {
   assert.throws(() => validateParentRegistry(repeatedPage), /must not repeat a page/);
 });
 
+// Resolve a menu link to the file the web server would actually serve: drop
+// any fragment, and read a directory link's index.html rather than the
+// directory itself, which readFile rejects with EISDIR.
+const linkTarget = (link) => {
+  const page = link.split('#')[0];
+  return page.endsWith('/') ? `${page}index.html` : page;
+};
+
 test('every page the menu links to is a page that exists', async () => {
   for (const item of registry.nav) {
-    const page = item.page.split('#')[0];
+    const page = linkTarget(item.page);
     await assert.doesNotReject(
       readFile(path.join(repoRoot, 'public', page), 'utf8'),
       `menu links to missing page: ${page}`
@@ -62,9 +70,10 @@ test('every page the menu links to is a page that exists', async () => {
   }
 
   for (const card of registry.cards) {
+    const page = linkTarget(card.page);
     await assert.doesNotReject(
-      readFile(path.join(repoRoot, 'public', card.page), 'utf8'),
-      `card links to missing page: ${card.page}`
+      readFile(path.join(repoRoot, 'public', page), 'utf8'),
+      `card links to missing page: ${page}`
     );
   }
 });


### PR DESCRIPTION
Light mode painted a near-white ground (`#f2f6f5`) behind white cards, white inputs and white result panels. At **1.09:1** against `#fff` nothing separated — the page read as one bright sheet with hairlines drawn on it.

This drops the ground to a muted teal (`#d7e7e3`, **~1.3:1** against `#fff`) so every card, input and dose readout sits on something instead of bleaching into it. The top glow goes `0.14` → `0.18` to stay visible over the deeper ground. Dark mode is untouched.

Two commits: the theme change, then a registry fix that turned out to be blocking CI.

## 1. The theme change

**`public/global.css`** — light-mode tokens:

| Token | Before | After |
| --- | --- | --- |
| `--page-bg` | `#f2f6f5` | `#d7e7e3` |
| page glow alpha | `0.14` | `0.18` |
| `--menu-overlay-bg` | `rgba(245, 249, 249, .98)` | `rgba(215, 231, 227, .98)` |
| `--on-bg-muted` | `rgba(15, 44, 42, .65)` | `rgba(15, 44, 42, .7)` |
| `--on-bg-link` | `var(--teal-500)` | `#14705f` |

Text that sits *straight on the ground*, rather than on a white card, follows it down:

- `--on-bg-muted` gains alpha: **4.32:1 → 4.98:1** on the new ground.
- `--on-bg-link` moves off `teal-500`, which only reaches **3.1:1** here, onto a deeper `#14705f` (**4.7:1**).
- New `--on-bg-link-hover` so the hover state can brighten in light mode *and* in dark mode without a third hardcoded teal.
- `.disclaimer-link`, `.editorial-eyebrow` and `.editorial-textlink` hardcoded `teal-500` on the ground; they now take `--on-bg-link`. Dark mode picks up `teal-400` there, which is a contrast gain too (**4.5:1 → 5.9:1**).

**`public/legal/legal.css`** — the legal pages carry their own light-only palette and mirror the ground rather than reading the token, so `--bg` moves to the same `#d7e7e3`; following a footer link no longer flashes back to near-white.

**`public/manifest.json`** — PWA splash `background_color` `#ffffff` → `#d7e7e3`, so launching the installed app doesn't flash white before CSS lands. `theme_color` was already teal and is unchanged.

### Verification

- Walked the rendered DOM on all seven public pages under Chromium and scored every text node whose *effective* background is the page ground (resolving translucent ancestors). **No element on the ground falls below its WCAG AA threshold in light mode.** The only remaining flags are elements painted by a gradient or watercolor image that a `background-color` walk can't see — `.editorial-cta` (white on the teal gradient pill) and `.support-care-card` (dark text on the watercolor).
- Screenshotted home / about / dosing / legal and the open menu overlay in light mode, plus home in dark mode to confirm no dark-mode drift.

### Left alone deliberately

- **`public/infant-breathing/`** — standalone page on its own slate/sky Tailwind palette; a teal ground would fight it.
- **`md/`** (provider hub), Jungle Run and the other embedded apps — separate token systems, not the parent site's light ground.

## 2. The registry fix (was blocking CI)

`verify` was already red on `main` before this branch: `sync-parent-tools.mjs --check` reported all nine parent pages stale.

The pages were not the side that drifted. #287 added the Infant Breathing Guide and hand-added its nav link everywhere; #288 then built `tools.registry.json` as the generator's source of truth and carried across eight of the nine links. So running the generator as the error message instructs would have **deleted the link to a live pediatric safety guide from every page** — a user-facing regression dressed up as a green build.

Fixed the other direction instead: restore the missing `nav` entry so the registry describes what is already shipped.

```json
{ "id": "breathing", "page": "infant-breathing/", "label": "Infant Breathing Guide" }
```

`sync` is now a **no-op on the markup** — zero HTML files change — which is the proof the entry matches byte for byte. `navPages` stays as it is: it lists pages that *carry* the generated menu, and `infant-breathing/` is standalone.

That then exposed a second gap in `tests/parent-tools.test.mjs`. The existence test read each nav target straight off disk, so a directory-style link rejected with `EISDIR` rather than resolving to its `index.html` — the registry had simply never held one before. Links now resolve the way the web server does (strip the fragment, then read `index.html` for a trailing slash), applied to cards too since they can take the same shape.

All four `verify` steps pass: `sync --check`, `parent-tools` (5/5), `i18n`, `voice`.
