### PR TITLE
Add bottle-label scanner, home-screen prompt, and share

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -12,6 +12,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose - About &amp; Support</title>
   <meta property="og:type" content="website" />
@@ -469,6 +473,7 @@
     </div>
   </div>
 
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
   <script async src="https://widgets.givebutter.com/latest.umd.cjs?acct=r8SGiZ0RhFRoIkXu&p=other"></script>
   <script>

--- a/public/allergy-calculator.html
+++ b/public/allergy-calculator.html
@@ -12,6 +12,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
@@ -76,6 +80,7 @@
   </div>
   <script src="allergy-calculator.js"></script>
   <script>window.addEventListener('DOMContentLoaded',function(){window.CloseDoseAllergyCalculator.mount(document.getElementById('allergy-calculator-root'));});</script>
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
 </body>
 </html>

--- a/public/cold-cough-guidance.html
+++ b/public/cold-cough-guidance.html
@@ -12,6 +12,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
@@ -99,6 +103,7 @@
       <button class="close-menu" type="button">Close</button>
     </div>
   </div>
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
 </body>
 </html>

--- a/public/dosing-guide.html
+++ b/public/dosing-guide.html
@@ -12,6 +12,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – How to measure liquid medicine</title>
   <meta property="og:type" content="website" />
@@ -509,6 +513,7 @@
     </div>
   </div>
 
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
 </body>
 </html>

--- a/public/global.css
+++ b/public/global.css
@@ -386,6 +386,7 @@ html[data-theme="dark"] {
   --cdcalc-result-card-p-color: #e2e8f0;
   --cdcalc-result-card-p-strong-color: #ffffff;
   --cdcalc-dose-mg-color: #cbd5e1;
+  --cdcalc-dose-ml-color: #0f2c2a;
   --cdcalc-result-weight-span-color: #9ca3af;
   --cdcalc-result-weight-strong-color: #ffffff;
   --cdcalc-result-disabled-bg: rgba(255, 255, 255, 0.03);
@@ -725,6 +726,7 @@ html[data-theme="dark"] .cdcalc-title {
     --cdcalc-result-card-p-color: #e2e8f0;
     --cdcalc-result-card-p-strong-color: #ffffff;
     --cdcalc-dose-mg-color: #cbd5e1;
+    --cdcalc-dose-ml-color: #0f2c2a;
     --cdcalc-result-weight-span-color: #9ca3af;
     --cdcalc-result-weight-strong-color: #ffffff;
     --cdcalc-result-disabled-bg: rgba(255, 255, 255, 0.03);

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,10 @@
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
   <link rel="manifest" href="manifest.json">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <script>(function(){var t=localStorage.getItem("cd-theme");if(t)document.documentElement.setAttribute("data-theme",t);})();</script>
 </head>
@@ -210,6 +214,7 @@
   </div>
 
   <script src="widget/close-dose-calculator.js"></script>
+  <script src="widget/label-scanner.js" defer></script>
   <script>
     window.addEventListener('DOMContentLoaded', function () {
       var host = document.querySelector('[data-calculator-root]');
@@ -220,6 +225,7 @@
   </script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
   <script async src="https://widgets.givebutter.com/latest.umd.cjs?acct=r8SGiZ0RhFRoIkXu&p=other"></script>
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
 </body>
 </html>

--- a/public/medication-guides.html
+++ b/public/medication-guides.html
@@ -11,6 +11,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – Medication Guides</title>
   <meta name="description" content="Browse acetaminophen and ibuprofen product guides with concentration-sorted photo galleries, formulation options, and pediatric safety tips." />
@@ -561,6 +565,7 @@
     </div>
   </div>
 
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
   <script>
     // Ibuprofen concentration tab switcher

--- a/public/pwa.js
+++ b/public/pwa.js
@@ -1,0 +1,469 @@
+/*
+ * CloseDose — Add to Home Screen + Share.
+ *
+ * Two small, self-contained features that share one stylesheet:
+ *
+ *   1. Add to Home Screen. On Android/Chrome we capture `beforeinstallprompt`
+ *      and drive the native installer. On iOS Safari there is no such event,
+ *      so we show the manual Share -> "Add to Home Screen" instructions with
+ *      the real iOS glyph. Either way the invitation appears once the person
+ *      has actually used the page, never on first paint, and a dismissal is
+ *      remembered for 60 days.
+ *
+ *   2. Share. `navigator.share` where available (the whole point on mobile),
+ *      clipboard copy as the fallback everywhere else. Injected into the site
+ *      header next to the menu button and into the menu panel.
+ *
+ * No dependencies. Drop in with:
+ *     <script src="/pwa.js" defer></script>
+ */
+(function (global) {
+  'use strict';
+
+  if (global.CloseDosePWA) return;
+
+  var doc = document;
+
+  var SHARE_URL = 'https://closedose.com/';
+  var SHARE_TITLE = 'CloseDose — pediatric dosing calculator';
+  var SHARE_TEXT =
+    'Free, physician-built pediatric dosing calculator. Acetaminophen and ibuprofen doses by weight in seconds — no account needed.';
+
+  var A2HS_KEY = 'cd-a2hs-dismissed';
+  var A2HS_DELAY_MS = 25000; // let them use the thing first
+  var A2HS_SNOOZE_DAYS = 60;
+
+  /* ------------------------------------------------------------------ *
+   * Environment
+   * ------------------------------------------------------------------ */
+
+  function isStandalone() {
+    return !!(
+      (global.matchMedia && global.matchMedia('(display-mode: standalone)').matches) ||
+      global.navigator.standalone === true
+    );
+  }
+
+  var ua = global.navigator.userAgent || '';
+  var isIOS =
+    /iPad|iPhone|iPod/.test(ua) ||
+    // iPadOS 13+ reports as Mac; the touch-point check separates them.
+    (/Macintosh/.test(ua) && global.navigator.maxTouchPoints > 1);
+  var isSafari = isIOS && !/CriOS|FxiOS|EdgiOS|OPiOS/.test(ua);
+
+  function track(name, params) {
+    try {
+      if (typeof global.gtag === 'function') global.gtag('event', name, params || {});
+    } catch (e) { /* analytics never breaks the UI */ }
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Styles
+   * ------------------------------------------------------------------ */
+
+  var CSS = [
+    /* shared button chrome, matched to the existing header controls */
+    '.cdpwa-iconbtn{appearance:none;border:0;cursor:pointer;font:inherit;display:inline-flex;',
+    'align-items:center;justify-content:center;gap:6px;min-height:44px;min-width:44px;',
+    'padding:0 12px;border-radius:var(--radius-pill,999px);color:var(--ink-900,#0f2c2a);',
+    'background:var(--card-bg,#fff);box-shadow:var(--shadow-btn,0 4px 12px rgba(15,44,42,.08));',
+    'border:var(--card-border,1px solid rgba(15,44,42,.1));font-weight:800;',
+    'font-size:var(--text-sm,.85rem);transition:transform .15s var(--ease-out,ease);}',
+    '.cdpwa-iconbtn:active{transform:translateY(1px);}',
+    '.cdpwa-iconbtn:focus-visible{outline:3px solid var(--teal-500,#1f8f7b);outline-offset:2px;}',
+    '.cdpwa-iconbtn svg{width:18px;height:18px;flex:0 0 auto;}',
+    '@media (max-width:520px){.cdpwa-iconbtn .cdpwa-iconbtn__label{',
+    'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;}}',
+
+    /* menu-panel variant sits on the dark overlay */
+    '.cdpwa-menuitem{width:100%;justify-content:flex-start;background:transparent;',
+    'border:1px solid var(--card-border-color,rgba(255,255,255,.18));',
+    'color:var(--menu-link-color,inherit);box-shadow:none;padding:12px 16px;',
+    'border-radius:var(--radius-sm,10px);margin-top:8px;}',
+    '.cdpwa-menuitem .cdpwa-iconbtn__label{position:static;width:auto;height:auto;clip:auto;}',
+
+    /* toast */
+    '.cdpwa-toast{position:fixed;left:50%;bottom:calc(24px + env(safe-area-inset-bottom,0px));',
+    'transform:translate(-50%,12px);z-index:1200;background:var(--ink-900,#0f2c2a);color:#fff;',
+    'padding:12px 20px;border-radius:999px;font-weight:800;font-size:.9rem;',
+    'font-family:var(--font-ui,system-ui,sans-serif);box-shadow:0 12px 28px rgba(0,0,0,.28);',
+    'opacity:0;pointer-events:none;transition:opacity .2s ease,transform .2s ease;}',
+    '.cdpwa-toast--on{opacity:1;transform:translate(-50%,0);}',
+
+    /* install invitation */
+    '.cdpwa-banner{position:fixed;left:12px;right:12px;',
+    'bottom:calc(12px + env(safe-area-inset-bottom,0px));z-index:1150;',
+    'max-width:520px;margin:0 auto;background:var(--card-bg,#fff);color:var(--ink-900,#0f2c2a);',
+    'border:var(--card-border,1px solid rgba(15,44,42,.12));border-radius:var(--radius-lg,20px);',
+    'box-shadow:var(--shadow-lg,0 22px 45px rgba(13,52,82,.18));padding:16px;',
+    'font-family:var(--font-ui,system-ui,sans-serif);',
+    'transform:translateY(140%);transition:transform .35s var(--ease-out,cubic-bezier(.16,1,.3,1));}',
+    '.cdpwa-banner--on{transform:translateY(0);}',
+    '@media (prefers-reduced-motion:reduce){.cdpwa-banner{transition:none;}}',
+    '.cdpwa-banner__row{display:flex;gap:12px;align-items:flex-start;}',
+    '.cdpwa-banner__icon{flex:0 0 auto;width:44px;height:44px;border-radius:12px;',
+    'object-fit:cover;background:rgba(36,166,135,.14);}',
+    '.cdpwa-banner__title{margin:0;font-size:1rem;font-weight:900;line-height:1.25;}',
+    '.cdpwa-banner__sub{margin:4px 0 0;font-size:.85rem;line-height:1.5;opacity:.85;}',
+    '.cdpwa-banner__close{appearance:none;border:0;background:transparent;cursor:pointer;',
+    'font-size:22px;line-height:1;color:inherit;opacity:.55;padding:4px 4px 4px 8px;',
+    'min-width:32px;min-height:32px;margin:-4px -4px 0 0;}',
+    '.cdpwa-banner__close:hover{opacity:1;}',
+    '.cdpwa-banner__actions{display:flex;gap:10px;margin-top:14px;}',
+    '.cdpwa-banner__cta{flex:1;appearance:none;border:0;cursor:pointer;font:inherit;font-weight:900;',
+    'background:var(--teal-500,#1f8f7b);color:#fff;border-radius:999px;padding:13px 18px;',
+    'min-height:48px;box-shadow:0 4px 0 rgba(15,44,42,.28);}',
+    '.cdpwa-banner__cta:active{transform:translateY(1px);}',
+    '.cdpwa-banner__cta:focus-visible{outline:3px solid var(--teal-500,#1f8f7b);outline-offset:3px;}',
+
+    /* iOS step-by-step */
+    '.cdpwa-steps{list-style:none;margin:14px 0 0;padding:0;display:grid;gap:10px;',
+    'font-size:.9rem;line-height:1.45;}',
+    '.cdpwa-steps li{display:flex;gap:10px;align-items:center;}',
+    '.cdpwa-steps b{display:inline-flex;align-items:center;justify-content:center;',
+    'flex:0 0 auto;width:24px;height:24px;border-radius:50%;background:rgba(36,166,135,.16);',
+    'font-size:.75rem;font-weight:900;}',
+    '.cdpwa-ios-glyph{display:inline-flex;vertical-align:-4px;margin:0 2px;}',
+    '.cdpwa-ios-glyph svg{width:16px;height:18px;}',
+  ].join('');
+
+  function injectStyles() {
+    if (doc.getElementById('cdpwa-styles')) return;
+    var s = doc.createElement('style');
+    s.id = 'cdpwa-styles';
+    s.textContent = CSS;
+    doc.head.appendChild(s);
+  }
+
+  var SHARE_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+    'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>' +
+    '<line x1="8.6" y1="10.5" x2="15.4" y2="6.5"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/></svg>';
+
+  /* The iOS share glyph, so the instructions point at something recognisable. */
+  var IOS_SHARE_GLYPH =
+    '<span class="cdpwa-ios-glyph" aria-hidden="true">' +
+    '<svg viewBox="0 0 20 24" fill="none" stroke="currentColor" stroke-width="1.8" ' +
+    'stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M10 2v12"/><path d="M6 6l4-4 4 4"/>' +
+    '<path d="M4.5 10H3.5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V11a1 1 0 0 0-1-1h-1"/>' +
+    '</svg></span>';
+
+  /* ------------------------------------------------------------------ *
+   * Toast
+   * ------------------------------------------------------------------ */
+
+  var toastEl = null;
+  var toastTimer = null;
+
+  function toast(message) {
+    if (!toastEl) {
+      toastEl = doc.createElement('div');
+      toastEl.className = 'cdpwa-toast';
+      toastEl.setAttribute('role', 'status');
+      toastEl.setAttribute('aria-live', 'polite');
+      doc.body.appendChild(toastEl);
+    }
+    toastEl.textContent = message;
+    // force reflow so the transition runs on repeat calls
+    void toastEl.offsetWidth;
+    toastEl.classList.add('cdpwa-toast--on');
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      toastEl.classList.remove('cdpwa-toast--on');
+    }, 2600);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Share
+   * ------------------------------------------------------------------ */
+
+  function share(source) {
+    var payload = { title: SHARE_TITLE, text: SHARE_TEXT, url: SHARE_URL };
+    track('share_click', { source: source || 'unknown' });
+
+    if (global.navigator.share) {
+      return global.navigator
+        .share(payload)
+        .then(function () {
+          track('share_complete', { method: 'web_share' });
+        })
+        .catch(function (err) {
+          // AbortError just means they closed the sheet. Not a failure.
+          if (!err || err.name !== 'AbortError') copyLink();
+        });
+    }
+    return copyLink();
+  }
+
+  function copyLink() {
+    function done() {
+      track('share_complete', { method: 'clipboard' });
+      toast('Link copied — paste it anywhere');
+    }
+
+    if (global.navigator.clipboard && global.navigator.clipboard.writeText) {
+      return global.navigator.clipboard
+        .writeText(SHARE_URL)
+        .then(done)
+        .catch(legacyCopy);
+    }
+    return Promise.resolve(legacyCopy());
+
+    function legacyCopy() {
+      try {
+        var ta = doc.createElement('textarea');
+        ta.value = SHARE_URL;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        doc.body.appendChild(ta);
+        ta.select();
+        doc.execCommand('copy');
+        doc.body.removeChild(ta);
+        done();
+      } catch (e) {
+        toast('Copy this link: closedose.com');
+      }
+    }
+  }
+
+  function makeShareButton(className, label, source) {
+    var b = doc.createElement('button');
+    b.type = 'button';
+    b.className = className;
+    b.setAttribute('aria-label', 'Share CloseDose');
+    b.innerHTML = SHARE_ICON + '<span class="cdpwa-iconbtn__label">Share</span>';
+    if (label) b.querySelector('.cdpwa-iconbtn__label').textContent = label;
+    b.addEventListener('click', function () {
+      share(source);
+    });
+    return b;
+  }
+
+  function mountShareButtons() {
+    // Header, next to the menu button.
+    var menuBtn = doc.querySelector('.menu-btn');
+    if (menuBtn && menuBtn.parentNode && !doc.querySelector('[data-cdpwa-share-header]')) {
+      var headerBtn = makeShareButton('cdpwa-iconbtn', 'Share', 'header');
+      headerBtn.setAttribute('data-cdpwa-share-header', '');
+      headerBtn.style.marginLeft = 'auto';
+      menuBtn.parentNode.insertBefore(headerBtn, menuBtn.nextSibling);
+    }
+
+    // Menu panel, above the close button.
+    var menuLinks = doc.querySelector('.menu-panel .menu-links');
+    if (menuLinks && menuLinks.parentNode && !doc.querySelector('[data-cdpwa-share-menu]')) {
+      var menuBtnEl = makeShareButton(
+        'cdpwa-iconbtn cdpwa-menuitem',
+        'Share CloseDose with someone',
+        'menu'
+      );
+      menuBtnEl.setAttribute('data-cdpwa-share-menu', '');
+      menuLinks.parentNode.insertBefore(menuBtnEl, menuLinks.nextSibling);
+    }
+
+    // Anything the site marks up itself.
+    Array.prototype.forEach.call(doc.querySelectorAll('[data-share-closedose]'), function (el) {
+      if (el.__cdpwaBound) return;
+      el.__cdpwaBound = true;
+      el.addEventListener('click', function (ev) {
+        ev.preventDefault();
+        share(el.getAttribute('data-share-closedose') || 'inline');
+      });
+    });
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Add to Home Screen
+   * ------------------------------------------------------------------ */
+
+  var deferredPrompt = null;
+  var bannerEl = null;
+
+  function snoozed() {
+    try {
+      var until = parseInt(global.localStorage.getItem(A2HS_KEY) || '0', 10);
+      return until > Date.now();
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function snooze() {
+    try {
+      global.localStorage.setItem(
+        A2HS_KEY,
+        String(Date.now() + A2HS_SNOOZE_DAYS * 864e5)
+      );
+    } catch (e) { /* private mode — just don't remember */ }
+  }
+
+  function closeBanner() {
+    if (!bannerEl) return;
+    bannerEl.classList.remove('cdpwa-banner--on');
+    var el = bannerEl;
+    bannerEl = null;
+    setTimeout(function () {
+      if (el && el.parentNode) el.parentNode.removeChild(el);
+    }, 400);
+  }
+
+  function buildBanner(mode) {
+    var el = doc.createElement('div');
+    el.className = 'cdpwa-banner';
+    el.setAttribute('role', 'dialog');
+    el.setAttribute('aria-label', 'Add CloseDose to your home screen');
+
+    var body =
+      mode === 'ios'
+        ? [
+            '<ol class="cdpwa-steps">',
+            '<li><b>1</b><span>Tap the Share button ' + IOS_SHARE_GLYPH + ' at the bottom of Safari.</span></li>',
+            '<li><b>2</b><span>Scroll down and tap <strong>Add to Home Screen</strong>.</span></li>',
+            '<li><b>3</b><span>Tap <strong>Add</strong>. CloseDose opens like an app.</span></li>',
+            '</ol>',
+            '<div class="cdpwa-banner__actions">',
+            '<button type="button" class="cdpwa-banner__cta" data-cdpwa-done>Got it</button>',
+            '</div>',
+          ].join('')
+        : [
+            '<div class="cdpwa-banner__actions">',
+            '<button type="button" class="cdpwa-banner__cta" data-cdpwa-install>Add to home screen</button>',
+            '</div>',
+          ].join('');
+
+    el.innerHTML = [
+      '<div class="cdpwa-banner__row">',
+      '<img class="cdpwa-banner__icon" src="/images/favicon-192.png" alt="" aria-hidden="true" width="44" height="44" />',
+      '<div style="flex:1">',
+      '<p class="cdpwa-banner__title">Keep CloseDose one tap away</p>',
+      '<p class="cdpwa-banner__sub">Add it to your home screen so it’s there at 2am without hunting for a browser tab.</p>',
+      '</div>',
+      '<button type="button" class="cdpwa-banner__close" data-cdpwa-close aria-label="Not now">&times;</button>',
+      '</div>',
+      body,
+    ].join('');
+
+    el.addEventListener('click', function (ev) {
+      var t = ev.target.closest('[data-cdpwa-close],[data-cdpwa-done],[data-cdpwa-install]');
+      if (!t) return;
+
+      if (t.hasAttribute('data-cdpwa-install')) {
+        track('a2hs_prompt_accept');
+        // Once we hand off to the browser's own installer we have had our
+        // say. Snooze either way — if they accept, `appinstalled` fires and
+        // the banner is moot; if they back out of the native sheet, asking
+        // again on the next page load would be nagging.
+        snooze();
+        if (deferredPrompt) {
+          deferredPrompt.prompt();
+          deferredPrompt.userChoice.then(function (choice) {
+            track('a2hs_outcome', { outcome: (choice && choice.outcome) || 'unknown' });
+            deferredPrompt = null;
+          });
+        }
+        closeBanner();
+        return;
+      }
+      // "Got it" and the close X both mean: stop asking for a while.
+      track(t.hasAttribute('data-cdpwa-done') ? 'a2hs_ios_ack' : 'a2hs_dismiss');
+      snooze();
+      closeBanner();
+    });
+
+    return el;
+  }
+
+  function showBanner(mode) {
+    if (bannerEl || isStandalone() || snoozed()) return;
+    injectStyles();
+    bannerEl = buildBanner(mode);
+    doc.body.appendChild(bannerEl);
+    // next frame so the slide-up transition actually runs
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        if (bannerEl) bannerEl.classList.add('cdpwa-banner--on');
+      });
+    });
+    track('a2hs_shown', { mode: mode });
+  }
+
+  function armInstallInvite() {
+    if (isStandalone() || snoozed()) return;
+
+    // Android / desktop Chrome: wait for the browser to say it's installable.
+    global.addEventListener('beforeinstallprompt', function (ev) {
+      ev.preventDefault();
+      deferredPrompt = ev;
+      setTimeout(function () {
+        showBanner('native');
+      }, A2HS_DELAY_MS);
+    });
+
+    global.addEventListener('appinstalled', function () {
+      track('a2hs_installed');
+      snooze();
+      closeBanner();
+    });
+
+    // iOS Safari has no install event, so offer the manual route.
+    if (isIOS && isSafari) {
+      setTimeout(function () {
+        showBanner('ios');
+      }, A2HS_DELAY_MS);
+    }
+  }
+
+  /*
+   * iOS only honours standalone display when this meta tag is present. It is
+   * normally set in the document head; we add it defensively so a page that
+   * ships without it still installs correctly.
+   */
+  function ensureIOSMeta() {
+    if (doc.querySelector('meta[name="apple-mobile-web-app-capable"]')) return;
+    ['apple-mobile-web-app-capable', 'mobile-web-app-capable'].forEach(function (name) {
+      var m = doc.createElement('meta');
+      m.name = name;
+      m.content = 'yes';
+      doc.head.appendChild(m);
+    });
+    var title = doc.createElement('meta');
+    title.name = 'apple-mobile-web-app-title';
+    title.content = 'CloseDose';
+    doc.head.appendChild(title);
+    var bar = doc.createElement('meta');
+    bar.name = 'apple-mobile-web-app-status-bar-style';
+    bar.content = 'default';
+    doc.head.appendChild(bar);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Boot
+   * ------------------------------------------------------------------ */
+
+  function init() {
+    injectStyles();
+    ensureIOSMeta();
+    mountShareButtons();
+    armInstallInvite();
+  }
+
+  global.CloseDosePWA = {
+    share: share,
+    copyLink: copyLink,
+    showInstallBanner: showBanner,
+    isStandalone: isStandalone,
+    /* exposed for the "Add to home screen" link some pages may want inline */
+    resetSnooze: function () {
+      try { global.localStorage.removeItem(A2HS_KEY); } catch (e) {}
+    },
+  };
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(window);

--- a/public/pwa.js
+++ b/public/pwa.js
@@ -49,7 +49,27 @@
     /iPad|iPhone|iPod/.test(ua) ||
     // iPadOS 13+ reports as Mac; the touch-point check separates them.
     (/Macintosh/.test(ua) && global.navigator.maxTouchPoints > 1);
-  var isSafari = isIOS && !/CriOS|FxiOS|EdgiOS|OPiOS/.test(ua);
+
+  var isIPad = /iPad/.test(ua) || (/Macintosh/.test(ua) && global.navigator.maxTouchPoints > 1);
+
+  /*
+   * Other iOS browsers announce themselves (CriOS, FxiOS...), but an in-app
+   * WKWebView — the browser you get tapping a link inside Facebook, Instagram,
+   * Gmail, LinkedIn — impersonates Safari almost exactly. The reliable tell is
+   * that real Safari carries a "Version/" token and embedded web views do not.
+   * This matters because Add to Home Screen exists ONLY in real Safari; showing
+   * its instructions anywhere else sends a caregiver looking for a button that
+   * is not there.
+   */
+  var IN_APP_MARKERS =
+    /FBAN|FBAV|FB_IAB|Instagram|LinkedInApp|Line\/|Twitter|Snapchat|Pinterest|TikTok|MicroMessenger|WhatsApp|GSA\//;
+  var OTHER_IOS_BROWSERS = /CriOS|FxiOS|EdgiOS|OPiOS|DuckDuckGo/;
+
+  var isInAppBrowser = isIOS && (IN_APP_MARKERS.test(ua) || !/Version\//.test(ua));
+  var isSafari =
+    isIOS && !OTHER_IOS_BROWSERS.test(ua) && !isInAppBrowser && /Version\//.test(ua);
+  /* iOS, but somewhere Add to Home Screen cannot be reached. */
+  var isIOSElsewhere = isIOS && !isSafari;
 
   function track(name, params) {
     try {
@@ -123,6 +143,13 @@
     '.cdpwa-steps b{display:inline-flex;align-items:center;justify-content:center;',
     'flex:0 0 auto;width:24px;height:24px;border-radius:50%;background:rgba(36,166,135,.16);',
     'font-size:.75rem;font-weight:900;}',
+    '.cdpwa-manual{margin-top:14px;padding-top:12px;',
+    'border-top:1px dashed var(--card-border-color,rgba(15,44,42,.18));}',
+    '.cdpwa-manual[hidden]{display:none;}',
+    '.cdpwa-manual__lead{margin:0;font-size:.85rem;font-weight:800;}',
+    '.cdpwa-linkcopy{appearance:none;border:0;background:transparent;cursor:pointer;font:inherit;',
+    'font-weight:800;font-size:.85rem;color:inherit;text-decoration:underline;',
+    'text-underline-offset:3px;padding:10px 0 2px;min-height:44px;}',
     '.cdpwa-ios-glyph{display:inline-flex;vertical-align:-4px;margin:0 2px;}',
     '.cdpwa-ios-glyph svg{width:16px;height:18px;}',
   ].join('');
@@ -310,22 +337,87 @@
     }, 400);
   }
 
+  /*
+   * Hand off to real Safari.
+   *
+   * `x-safari-https://` is undocumented but is the only thing that reliably
+   * escapes an in-app WKWebView, and it is what the ecosystem has settled on.
+   * Being undocumented, it can silently do nothing — so we watch for the page
+   * being backgrounded, and if we are still here a moment later we reveal the
+   * manual route rather than leaving a dead button. Only meaningful over
+   * https; on plain http there is nothing sensible to hand off.
+   */
+  function openInSafari(bannerEl) {
+    var manual = bannerEl && bannerEl.querySelector('[data-cdpwa-manual]');
+
+    function revealManual() {
+      if (manual) manual.hidden = false;
+      track('a2hs_safari_handoff_failed');
+    }
+
+    if (global.location.protocol !== 'https:') {
+      revealManual();
+      return;
+    }
+
+    var target =
+      'x-safari-https://' +
+      global.location.host +
+      global.location.pathname +
+      global.location.search +
+      global.location.hash;
+
+    var timer = setTimeout(revealManual, 1400);
+    function onHide() {
+      if (doc.hidden) {
+        clearTimeout(timer);
+        doc.removeEventListener('visibilitychange', onHide);
+      }
+    }
+    doc.addEventListener('visibilitychange', onHide);
+
+    try {
+      global.location.href = target;
+    } catch (e) {
+      clearTimeout(timer);
+      revealManual();
+    }
+  }
+
   function buildBanner(mode) {
     var el = doc.createElement('div');
     el.className = 'cdpwa-banner';
     el.setAttribute('role', 'dialog');
     el.setAttribute('aria-label', 'Add CloseDose to your home screen');
 
+    var shareWhere = isIPad
+      ? 'in the top-right corner of Safari'
+      : 'at the bottom of Safari';
+
     var body =
       mode === 'ios'
         ? [
             '<ol class="cdpwa-steps">',
-            '<li><b>1</b><span>Tap the Share button ' + IOS_SHARE_GLYPH + ' at the bottom of Safari.</span></li>',
+            '<li><b>1</b><span>Tap the Share button ' + IOS_SHARE_GLYPH + ' ' + shareWhere + '.</span></li>',
             '<li><b>2</b><span>Scroll down and tap <strong>Add to Home Screen</strong>.</span></li>',
             '<li><b>3</b><span>Tap <strong>Add</strong>. CloseDose opens like an app.</span></li>',
             '</ol>',
             '<div class="cdpwa-banner__actions">',
             '<button type="button" class="cdpwa-banner__cta" data-cdpwa-done>Got it</button>',
+            '</div>',
+          ].join('')
+        : mode === 'ios-elsewhere'
+        ? [
+            '<div class="cdpwa-banner__actions">',
+            '<button type="button" class="cdpwa-banner__cta" data-cdpwa-safari>Open in Safari</button>',
+            '</div>',
+            '<div class="cdpwa-manual" data-cdpwa-manual hidden>',
+            '<p class="cdpwa-manual__lead">If nothing opened, do it by hand:</p>',
+            '<ol class="cdpwa-steps">',
+            '<li><b>1</b><span>Tap the <strong>&hellip;</strong> or share icon in this app\u2019s toolbar.</span></li>',
+            '<li><b>2</b><span>Choose <strong>Open in Safari</strong> (or <strong>Open in browser</strong>).</span></li>',
+            '</ol>',
+            '<button type="button" class="cdpwa-linkcopy" data-cdpwa-copy>Copy the link instead</button>',
             '</div>',
           ].join('')
         : [
@@ -334,12 +426,21 @@
             '</div>',
           ].join('');
 
+    var title =
+      mode === 'ios-elsewhere'
+        ? 'Open CloseDose in Safari'
+        : 'Keep CloseDose one tap away';
+    var sub =
+      mode === 'ios-elsewhere'
+        ? 'Adding CloseDose to your home screen only works from Safari — this browser can’t do it.'
+        : 'Add it to your home screen so it’s there at 2am without hunting for a browser tab.';
+
     el.innerHTML = [
       '<div class="cdpwa-banner__row">',
       '<img class="cdpwa-banner__icon" src="/images/favicon-192.png" alt="" aria-hidden="true" width="44" height="44" />',
       '<div style="flex:1">',
-      '<p class="cdpwa-banner__title">Keep CloseDose one tap away</p>',
-      '<p class="cdpwa-banner__sub">Add it to your home screen so it’s there at 2am without hunting for a browser tab.</p>',
+      '<p class="cdpwa-banner__title">' + title + '</p>',
+      '<p class="cdpwa-banner__sub">' + sub + '</p>',
       '</div>',
       '<button type="button" class="cdpwa-banner__close" data-cdpwa-close aria-label="Not now">&times;</button>',
       '</div>',
@@ -347,8 +448,20 @@
     ].join('');
 
     el.addEventListener('click', function (ev) {
-      var t = ev.target.closest('[data-cdpwa-close],[data-cdpwa-done],[data-cdpwa-install]');
+      var t = ev.target.closest(
+        '[data-cdpwa-close],[data-cdpwa-done],[data-cdpwa-install],[data-cdpwa-safari],[data-cdpwa-copy]'
+      );
       if (!t) return;
+
+      if (t.hasAttribute('data-cdpwa-safari')) {
+        track('a2hs_open_in_safari');
+        openInSafari(el);
+        return;
+      }
+      if (t.hasAttribute('data-cdpwa-copy')) {
+        copyLink();
+        return;
+      }
 
       if (t.hasAttribute('data-cdpwa-install')) {
         track('a2hs_prompt_accept');
@@ -409,9 +522,23 @@
     });
 
     // iOS Safari has no install event, so offer the manual route.
-    if (isIOS && isSafari) {
+    if (isSafari) {
       setTimeout(function () {
         showBanner('ios');
+      }, A2HS_DELAY_MS);
+      return;
+    }
+
+    /*
+     * Everywhere else on iOS — Chrome, Firefox, or the in-app browser someone
+     * lands in from a text or a Facebook group — Add to Home Screen does not
+     * exist. Previously these visitors saw nothing at all, which is the worst
+     * outcome for a product meant to spread parent to parent. Send them to
+     * Safari instead.
+     */
+    if (isIOSElsewhere) {
+      setTimeout(function () {
+        showBanner('ios-elsewhere');
       }, A2HS_DELAY_MS);
     }
   }
@@ -455,6 +582,28 @@
     copyLink: copyLink,
     showInstallBanner: showBanner,
     isStandalone: isStandalone,
+    /*
+     * What this browser was detected as, and which invitation it will get.
+     * Exposed so the branch can be asserted in tests and read off a real
+     * device when a caregiver reports the wrong prompt.
+     */
+    environment: function () {
+      return {
+        isIOS: isIOS,
+        isIPad: isIPad,
+        isSafari: isSafari,
+        isInAppBrowser: isInAppBrowser,
+        isIOSElsewhere: isIOSElsewhere,
+        standalone: isStandalone(),
+        mode: isStandalone()
+          ? 'none'
+          : isSafari
+          ? 'ios'
+          : isIOSElsewhere
+          ? 'ios-elsewhere'
+          : 'native',
+      };
+    },
     /* exposed for the "Add to home screen" link some pages may want inline */
     resetSnooze: function () {
       try { global.localStorage.removeItem(A2HS_KEY); } catch (e) {}

--- a/public/weighing-guide.html
+++ b/public/weighing-guide.html
@@ -12,6 +12,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="apple-touch-icon" href="images/favicon-192.png">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="CloseDose" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <link rel="stylesheet" href="global.css" />
   <title>CloseDose – How to weigh your baby at home</title>
   <meta property="og:type" content="website" />
@@ -183,6 +187,7 @@
     </div>
   </div>
 
+  <script src="/pwa.js" defer></script>
   <script src="global.js" defer></script>
   <script>
     // No-tare button expand/collapse

--- a/public/widget/close-dose-calculator.js
+++ b/public/widget/close-dose-calculator.js
@@ -730,7 +730,11 @@
 
     .cdcalc-dose-ml {
       display: inline-block;
-      font-size: clamp(1.8rem, 5vw, 2.4rem);
+      /* Sized and padded to read as a distinct chip rather than a tight band
+         behind the glyph. The volume to measure is the one number a caregiver
+         has to find at a glance, so it gets real breathing room inside its
+         ground and a defined edge to separate it from the sentence around it. */
+      font-size: clamp(2rem, 6vw, 2.6rem);
       font-weight: 900;
       letter-spacing: 0.01em;
       /* The pill keeps its gold ground in both themes, so its ink must not
@@ -739,16 +743,17 @@
          own token so a theme can never wash it out. */
       color: var(--cdcalc-dose-ml-color, var(--cdcalc-result-title-color, #0f2c2a));
       background: var(--cdcalc-dose-ml-bg, var(--cdcalc-gold, #ffe8a8));
-      padding: 2px 12px;
-      border-radius: 12px;
-      margin: 0 6px 0 2px;
-      line-height: 1.15;
+      padding: 10px 18px;
+      border-radius: 14px;
+      margin: 6px 8px 6px 0;
+      line-height: 1.05;
       vertical-align: middle;
+      box-shadow: inset 0 0 0 2px var(--cdcalc-dose-ml-edge, rgba(15, 44, 42, 0.22));
     }
 
     .cdcalc-dose-mg {
       display: inline-block;
-      font-size: 0.95rem;
+      font-size: 1rem;
       font-weight: 700;
       color: var(--cdcalc-dose-mg-color, #124643);
       margin-right: 6px;

--- a/public/widget/close-dose-calculator.js
+++ b/public/widget/close-dose-calculator.js
@@ -89,8 +89,11 @@
       acetaminophenOlderBody:
         'Give <span class="cdcalc-dose-ml">{{ml}} mL</span><span class="cdcalc-dose-mg">({{mg}} mg)</span> every 6 hours as needed for fever/pain.',
       ibuprofenTitle: 'Ibuprofen (oral)',
-      ibuprofenChildrenSummary: "Children's 100 mg / 5 mL (recommended)",
-      ibuprofenInfantSummary: "Infant's 50 mg / 1.25 mL (concentrated drops)",
+      ibuprofenConcIf: 'If your bottle says',
+      ibuprofenConc100: '100 mg / 5 mL',
+      ibuprofenConc50: '50 mg / 1.25 mL',
+      ibuprofenChildrenSummary: "Children's suspension \u2014 the most common bottle",
+      ibuprofenInfantSummary: "Infants' concentrated drops",
       ibuprofenBody100:
         'Give <span class="cdcalc-dose-ml">{{ml}} mL</span><span class="cdcalc-dose-mg">({{mg}} mg)</span> every 6 hours as needed for fever/pain.',
       ibuprofenBody50:
@@ -730,7 +733,11 @@
       font-size: clamp(1.8rem, 5vw, 2.4rem);
       font-weight: 900;
       letter-spacing: 0.01em;
-      color: var(--cdcalc-result-title-color, #0f2c2a);
+      /* The pill keeps its gold ground in both themes, so its ink must not
+         follow --cdcalc-result-title-color (white in dark mode -> 1.2:1 on
+         gold). This is the number a caregiver actually measures; it gets its
+         own token so a theme can never wash it out. */
+      color: var(--cdcalc-dose-ml-color, var(--cdcalc-result-title-color, #0f2c2a));
       background: var(--cdcalc-dose-ml-bg, var(--cdcalc-gold, #ffe8a8));
       padding: 2px 12px;
       border-radius: 12px;
@@ -763,6 +770,61 @@
       text-decoration: underline;
       text-decoration-thickness: 2px;
       text-underline-offset: 2px;
+    }
+
+    /* Concentration check — ibuprofen ships in two strengths and the volume
+       differs between them. Both options stay visible and equally weighted;
+       the concentration printed on the bottle is the entry condition, so a
+       caregiver matches their bottle first and reads the dose second. Never
+       collapse one of these or pre-select a "default" strength: the hidden
+       option is the one that causes the overdose. */
+    .cdcalc-conc-check {
+      display: grid;
+      gap: 10px;
+    }
+
+    .cdcalc-conc-option {
+      border-radius: 14px;
+      border: 2px solid var(--cdcalc-accordion-border-color, #0f2c2a);
+      background: var(--cdcalc-accordion-bg, #ffffff);
+      padding: 14px;
+      display: grid;
+      gap: 2px;
+    }
+
+    .cdcalc-conc-option__if {
+      margin: 0;
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.72;
+    }
+
+    .cdcalc-conc-option__conc {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 900;
+      line-height: 1.15;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .cdcalc-conc-option__meta {
+      margin: 0 0 6px;
+      font-size: 0.82rem;
+      opacity: 0.78;
+    }
+
+    .cdcalc-conc-option__dose {
+      margin: 0;
+      padding-top: 8px;
+      border-top: 1px dashed var(--cdcalc-accordion-border-color, rgba(15, 44, 42, 0.35));
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    @media (max-width: 640px) {
+      .cdcalc-conc-option__conc { font-size: 1.15rem; }
     }
 
     .cdcalc-accordion {
@@ -1619,24 +1681,26 @@
         <article class="cdcalc-result-card">
           <h3>${strings.results.ibuprofenTitle}</h3>
           <div class="cdcalc-info-banner">${strings.warnings.ibuprofenStrengthInfo}</div>
-          <details class="cdcalc-accordion" open>
-            <summary>${strings.results.ibuprofenChildrenSummary}</summary>
-            <div class="cdcalc-accordion-body">
-              <p>${formatString(strings.results.ibuprofenBody100, {
+          <div class="cdcalc-conc-check">
+            <div class="cdcalc-conc-option">
+              <p class="cdcalc-conc-option__if">${strings.results.ibuprofenConcIf}</p>
+              <p class="cdcalc-conc-option__conc">${strings.results.ibuprofenConc100}</p>
+              <p class="cdcalc-conc-option__meta">${strings.results.ibuprofenChildrenSummary}</p>
+              <p class="cdcalc-conc-option__dose">${formatString(strings.results.ibuprofenBody100, {
                 ml: ibuMl100.toFixed(1),
                 mg: ibuMg.toFixed(0),
               })}</p>
             </div>
-          </details>
-          <details class="cdcalc-accordion">
-            <summary>${strings.results.ibuprofenInfantSummary}</summary>
-            <div class="cdcalc-accordion-body">
-              <p>${formatString(strings.results.ibuprofenBody50, {
+            <div class="cdcalc-conc-option">
+              <p class="cdcalc-conc-option__if">${strings.results.ibuprofenConcIf}</p>
+              <p class="cdcalc-conc-option__conc">${strings.results.ibuprofenConc50}</p>
+              <p class="cdcalc-conc-option__meta">${strings.results.ibuprofenInfantSummary}</p>
+              <p class="cdcalc-conc-option__dose">${formatString(strings.results.ibuprofenBody50, {
                 ml: ibuMl50.toFixed(1),
                 mg: ibuMg.toFixed(0),
               })}</p>
             </div>
-          </details>
+          </div>
           ${
             ibuCapped
               ? renderWarning(strings, {

--- a/public/widget/label-scanner.js
+++ b/public/widget/label-scanner.js
@@ -1,0 +1,860 @@
+/*
+ * CloseDose — bottle label scanner.
+ *
+ * Lets a caregiver photograph the front of an OTC fever/pain medicine bottle
+ * and get back a plain-English answer to the two questions that actually cause
+ * dosing errors at 3am:
+ *
+ *     1. Which medicine is this?           (acetaminophen vs ibuprofen)
+ *     2. How strong is it?                 (the concentration on the label)
+ *
+ * Everything runs on the device. The photo is drawn to a canvas, OCR'd with
+ * Tesseract.js, and matched against a small table of US OTC products. The
+ * image is never uploaded, never stored, and is released as soon as the read
+ * finishes. That is a deliberate choice for a children's health product.
+ *
+ * SAFETY POSTURE — read before editing:
+ *   - OCR is treated as a *suggestion*, never as truth. Every result is shown
+ *     back to the caregiver for visual confirmation against the bottle in
+ *     their hand before it is used for anything.
+ *   - The scanner identifies the product. It does not calculate a dose. Dose
+ *     math stays in the calculator, which requires a weight.
+ *   - An unreadable photo must fail loudly to the manual picker. Guessing is
+ *     worse than asking.
+ *
+ * Usage:  <script src="widget/label-scanner.js" defer></script>
+ * Mounts into [data-label-scanner], or self-inserts above the calculator card.
+ */
+(function (global) {
+  'use strict';
+
+  if (global.CloseDoseLabelScanner) return;
+
+  /*
+   * The OCR engine is loaded from jsDelivr on demand — nothing is fetched
+   * until the caregiver actually taps "Scan the bottle", so the page weight
+   * is unchanged for everyone else. If the CDN is ever unreachable the
+   * scanner degrades to the manual picker rather than failing shut.
+   *
+   * To self-host instead (larger repo, no third-party dependency at runtime),
+   * set window.CLOSEDOSE_SCANNER_CONFIG before this script loads:
+   *
+   *     window.CLOSEDOSE_SCANNER_CONFIG = {
+   *       scriptUrl: '/vendor/tess/tesseract.min.js',
+   *       workerPath: '/vendor/tess/worker.min.js',
+   *       corePath:   '/vendor/tess/',
+   *       langPath:   '/vendor/tess/'
+   *     };
+   */
+  var CONFIG = global.CLOSEDOSE_SCANNER_CONFIG || {};
+
+  var TESSERACT_CDN =
+    CONFIG.scriptUrl ||
+    'https://cdn.jsdelivr.net/npm/tesseract.js@5.1.1/dist/tesseract.min.js';
+
+  /* ------------------------------------------------------------------ *
+   * Product table
+   *
+   * Only US OTC antipyretic/analgesic products a caregiver would plausibly
+   * be holding. `match` scores a normalised OCR string; the highest scoring
+   * product wins, provided it clears MIN_CONFIDENCE.
+   * ------------------------------------------------------------------ */
+
+  var PRODUCTS = [
+    {
+      id: 'apap-susp-160-5',
+      drug: 'Acetaminophen',
+      brand: 'Tylenol (Infants’ or Children’s)',
+      form: 'Liquid suspension',
+      strength: '160 mg per 5 mL',
+      calcNote:
+        'This is the standard strength CloseDose uses for acetaminophen.',
+      tone: 'ok',
+      ingredient: 'acetaminophen',
+      concentration: { mg: 160, ml: 5 },
+    },
+    {
+      id: 'apap-drops-80-08',
+      drug: 'Acetaminophen',
+      brand: 'Older concentrated infant drops',
+      form: 'Concentrated drops',
+      strength: '80 mg per 0.8 mL',
+      calcNote:
+        'These concentrated drops were discontinued in the US in 2011 because the strength was so easy to mix up with the 160 mg / 5 mL liquid. If this bottle is still in your cabinet, check the expiration date and consider replacing it. Do not use a CloseDose dose calculated for 160 mg / 5 mL with this bottle — the volumes are completely different.',
+      tone: 'danger',
+      ingredient: 'acetaminophen',
+      concentration: { mg: 80, ml: 0.8 },
+    },
+    {
+      id: 'apap-chew-160',
+      drug: 'Acetaminophen',
+      brand: 'Children’s or Jr. chewable',
+      form: 'Chewable tablet',
+      strength: '160 mg per tablet',
+      calcNote:
+        'Chewable tablets are dosed in whole tablets, not mL. Only for children who can reliably chew and swallow tablets.',
+      tone: 'ok',
+      ingredient: 'acetaminophen',
+      concentration: { mg: 160, unit: 'tablet' },
+    },
+    {
+      id: 'apap-adult-325',
+      drug: 'Acetaminophen',
+      brand: 'Regular Strength (adult)',
+      form: 'Tablet',
+      strength: '325 mg per tablet',
+      calcNote:
+        'This is an adult tablet. Do not use it for a young child — use a children’s liquid or chewable and confirm with your pediatrician.',
+      tone: 'warn',
+      ingredient: 'acetaminophen',
+      concentration: { mg: 325, unit: 'tablet' },
+    },
+    {
+      id: 'apap-adult-500',
+      drug: 'Acetaminophen',
+      brand: 'Extra Strength (adult)',
+      form: 'Tablet or caplet',
+      strength: '500 mg per tablet',
+      calcNote:
+        'This is an adult tablet. Do not use it for a young child — use a children’s liquid or chewable and confirm with your pediatrician.',
+      tone: 'warn',
+      ingredient: 'acetaminophen',
+      concentration: { mg: 500, unit: 'tablet' },
+    },
+    {
+      id: 'ibu-susp-100-5',
+      drug: 'Ibuprofen',
+      brand: 'Children’s Motrin or Advil',
+      form: 'Liquid suspension',
+      strength: '100 mg per 5 mL',
+      calcNote:
+        'This is the strength CloseDose recommends for ibuprofen. Not for infants under 6 months.',
+      tone: 'ok',
+      ingredient: 'ibuprofen',
+      concentration: { mg: 100, ml: 5 },
+    },
+    {
+      id: 'ibu-drops-50-125',
+      drug: 'Ibuprofen',
+      brand: 'Infants’ Motrin or Advil drops',
+      form: 'Concentrated drops',
+      strength: '50 mg per 1.25 mL',
+      calcNote:
+        'These infant drops are more concentrated than the children’s liquid. A dose calculated for 100 mg / 5 mL will be the wrong volume for this bottle — make sure you are reading the right line in the calculator. Not for infants under 6 months.',
+      tone: 'warn',
+      ingredient: 'ibuprofen',
+      concentration: { mg: 50, ml: 1.25 },
+    },
+    {
+      id: 'ibu-chew-100',
+      drug: 'Ibuprofen',
+      brand: 'Junior Strength chewable',
+      form: 'Chewable tablet',
+      strength: '100 mg per tablet',
+      calcNote:
+        'Chewable tablets are dosed in whole tablets, not mL. Only for children who can reliably chew and swallow tablets.',
+      tone: 'ok',
+      ingredient: 'ibuprofen',
+      concentration: { mg: 100, unit: 'tablet' },
+    },
+    {
+      id: 'ibu-adult-200',
+      drug: 'Ibuprofen',
+      brand: 'Advil or Motrin IB (adult)',
+      form: 'Tablet, caplet, or gel cap',
+      strength: '200 mg per tablet',
+      calcNote:
+        'This is an adult tablet. Do not use it for a young child — use a children’s liquid or chewable and confirm with your pediatrician.',
+      tone: 'warn',
+      ingredient: 'ibuprofen',
+      concentration: { mg: 200, unit: 'tablet' },
+    },
+  ];
+
+  /* Products offered in the manual picker, in the order a parent is most
+     likely to be holding one. */
+  var MANUAL_ORDER = [
+    'apap-susp-160-5',
+    'ibu-susp-100-5',
+    'ibu-drops-50-125',
+    'apap-chew-160',
+    'ibu-chew-100',
+    'apap-drops-80-08',
+    'apap-adult-500',
+    'apap-adult-325',
+    'ibu-adult-200',
+  ];
+
+  var MIN_CONFIDENCE = 3; // ingredient hit (2) + at least one weak signal
+
+  /* ------------------------------------------------------------------ *
+   * Text normalisation + matching
+   * ------------------------------------------------------------------ */
+
+  /*
+   * OCR on a glossy, curved bottle label reliably confuses a handful of
+   * glyph pairs. We only apply digit-restoring substitutions inside runs that
+   * already look numeric, so we don't corrupt real words.
+   */
+  function normalise(raw) {
+    var text = String(raw || '')
+      .toUpperCase()
+      .replace(/[‘’“”]/g, '')
+      .replace(/[^A-Z0-9./\s-]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    // Repair digits inside numeric-looking tokens: "16O MG" -> "160 MG".
+    text = text.replace(/\b[0-9OISBZlL.]{2,6}\b(?=\s*(MG|ML|M[GL]))/g, function (tok) {
+      return tok
+        .replace(/O/g, '0')
+        .replace(/I/g, '1')
+        .replace(/L/g, '1')
+        .replace(/S/g, '5')
+        .replace(/B/g, '8')
+        .replace(/Z/g, '2');
+    });
+
+    // Unify unit spellings: ML, M L, MLS, MILLILITER(S) -> ML
+    text = text
+      .replace(/\bMILLI\s?LITERS?\b/g, 'ML')
+      .replace(/\bMILLI\s?GRAMS?\b/g, 'MG')
+      .replace(/\bM\s+L\b/g, 'ML')
+      .replace(/\bM\s+G\b/g, 'MG')
+      .replace(/\bMLS\b/g, 'ML')
+      .replace(/\bMGS\b/g, 'MG');
+
+    return text;
+  }
+
+  var INGREDIENT_TERMS = {
+    acetaminophen: [
+      'ACETAMINOPHEN',
+      'ACETAMINOPHIN',
+      'PARACETAMOL',
+      'APAP',
+      'TYLENOL',
+      'FEVERALL',
+    ],
+    ibuprofen: ['IBUPROFEN', 'IBUPROFIN', 'MOTRIN', 'ADVIL'],
+  };
+
+  function detectIngredient(text) {
+    var found = [];
+    Object.keys(INGREDIENT_TERMS).forEach(function (key) {
+      var hit = INGREDIENT_TERMS[key].some(function (term) {
+        return text.indexOf(term) !== -1;
+      });
+      if (hit) found.push(key);
+    });
+    return found;
+  }
+
+  /*
+   * Pull every "<number> MG" / "<number> ML" pair out of the text, plus
+   * explicit ratios like "160 MG PER 5 ML" or "160MG/5ML".
+   */
+  function extractNumbers(text) {
+    var mg = [];
+    var ml = [];
+    var ratios = [];
+
+    var ratioRe = /(\d+(?:\.\d+)?)\s*MG\s*(?:PER|\/|IN|-)?\s*(\d+(?:\.\d+)?)\s*ML/g;
+    var m;
+    while ((m = ratioRe.exec(text)) !== null) {
+      ratios.push({ mg: parseFloat(m[1]), ml: parseFloat(m[2]) });
+    }
+
+    var mgRe = /(\d+(?:\.\d+)?)\s*MG\b/g;
+    while ((m = mgRe.exec(text)) !== null) mg.push(parseFloat(m[1]));
+
+    var mlRe = /(\d+(?:\.\d+)?)\s*ML\b/g;
+    while ((m = mlRe.exec(text)) !== null) ml.push(parseFloat(m[1]));
+
+    return { mg: mg, ml: ml, ratios: ratios };
+  }
+
+  function hasForm(text, product) {
+    if (product.concentration.unit === 'tablet') {
+      return /CHEWABLE|TABLET|CAPLET|MELTAWAY|GEL\s?CAP|SOFTGEL/.test(text);
+    }
+    return /SUSPENSION|LIQUID|ORAL\s?SOLUTION|DROPS|SYRUP|CONCENTRATED/.test(text);
+  }
+
+  function scoreProduct(product, text, nums) {
+    var ingredients = detectIngredient(text);
+    if (ingredients.indexOf(product.ingredient) === -1) return 0;
+
+    var score = 2; // correct active ingredient
+    var conc = product.concentration;
+
+    // Strongest signal: an explicit mg/mL ratio that matches exactly.
+    var ratioMatch = nums.ratios.some(function (r) {
+      return conc.ml && r.mg === conc.mg && Math.abs(r.ml - conc.ml) < 0.01;
+    });
+    if (ratioMatch) score += 5;
+
+    // Both numbers present somewhere on the label.
+    if (conc.ml) {
+      var mgSeen = nums.mg.indexOf(conc.mg) !== -1;
+      var mlSeen = nums.ml.some(function (v) {
+        return Math.abs(v - conc.ml) < 0.01;
+      });
+      if (mgSeen && mlSeen && !ratioMatch) score += 3;
+      else if (mgSeen) score += 1;
+    } else {
+      // Tablet: the mg number alone is the signal.
+      if (nums.mg.indexOf(conc.mg) !== -1) score += 3;
+    }
+
+    if (hasForm(text, product)) score += 1;
+
+    // Brand-name corroboration.
+    if (/INFANT/.test(text) && /drops|Infants/i.test(product.brand)) score += 1;
+    if (/CHILDREN/.test(text) && /Children/i.test(product.brand)) score += 1;
+    if (/JUNIOR|JR/.test(text) && /Jr|Junior/i.test(product.brand)) score += 1;
+
+    return score;
+  }
+
+  function identify(rawText) {
+    var text = normalise(rawText);
+    var nums = extractNumbers(text);
+
+    var scored = PRODUCTS.map(function (p) {
+      return { product: p, score: scoreProduct(p, text, nums) };
+    })
+      .filter(function (s) {
+        return s.score > 0;
+      })
+      .sort(function (a, b) {
+        return b.score - a.score;
+      });
+
+    var ingredients = detectIngredient(text);
+    var best = scored[0] || null;
+    var runnerUp = scored[1] || null;
+
+    // A near-tie between two different strengths of the same drug is exactly
+    // the situation where a confident answer is dangerous. Force confirmation.
+    var ambiguous =
+      !!(best && runnerUp && best.score - runnerUp.score <= 1);
+
+    return {
+      text: text,
+      ingredients: ingredients,
+      best: best && best.score >= MIN_CONFIDENCE ? best.product : null,
+      score: best ? best.score : 0,
+      ambiguous: ambiguous,
+      alternatives: scored.slice(0, 3).map(function (s) {
+        return s.product;
+      }),
+    };
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Image preprocessing
+   *
+   * Tesseract does markedly better on a downscaled, greyscale, contrast-
+   * stretched image than on a 12-megapixel phone photo. This also keeps the
+   * read fast enough to be usable one-handed.
+   * ------------------------------------------------------------------ */
+
+  var MAX_EDGE = 1600;
+
+  function preprocess(file) {
+    return new Promise(function (resolve, reject) {
+      var url = URL.createObjectURL(file);
+      var img = new Image();
+      img.onload = function () {
+        try {
+          var scale = Math.min(1, MAX_EDGE / Math.max(img.width, img.height));
+          var w = Math.round(img.width * scale);
+          var h = Math.round(img.height * scale);
+
+          var canvas = document.createElement('canvas');
+          canvas.width = w;
+          canvas.height = h;
+          var ctx = canvas.getContext('2d', { willReadFrequently: true });
+          ctx.drawImage(img, 0, 0, w, h);
+
+          var data = ctx.getImageData(0, 0, w, h);
+          var px = data.data;
+          var i;
+
+          // Greyscale (luma) and gather a histogram for contrast stretching.
+          var hist = new Uint32Array(256);
+          for (i = 0; i < px.length; i += 4) {
+            var v = (px[i] * 0.299 + px[i + 1] * 0.587 + px[i + 2] * 0.114) | 0;
+            px[i] = px[i + 1] = px[i + 2] = v;
+            hist[v]++;
+          }
+
+          // Clip the darkest/lightest 1% and stretch what's left to 0-255.
+          var total = w * h;
+          var clip = total * 0.01;
+          var lo = 0;
+          var hi = 255;
+          var acc = 0;
+          for (i = 0; i < 256; i++) {
+            acc += hist[i];
+            if (acc > clip) { lo = i; break; }
+          }
+          acc = 0;
+          for (i = 255; i >= 0; i--) {
+            acc += hist[i];
+            if (acc > clip) { hi = i; break; }
+          }
+          var range = Math.max(1, hi - lo);
+          for (i = 0; i < px.length; i += 4) {
+            var s = ((px[i] - lo) * 255) / range;
+            s = s < 0 ? 0 : s > 255 ? 255 : s;
+            px[i] = px[i + 1] = px[i + 2] = s;
+          }
+
+          ctx.putImageData(data, 0, 0);
+          URL.revokeObjectURL(url);
+          resolve({ canvas: canvas, width: w, height: h });
+        } catch (err) {
+          URL.revokeObjectURL(url);
+          reject(err);
+        }
+      };
+      img.onerror = function () {
+        URL.revokeObjectURL(url);
+        reject(new Error('Could not read that image.'));
+      };
+      img.src = url;
+    });
+  }
+
+  /* ------------------------------------------------------------------ *
+   * OCR engine (lazy loaded)
+   * ------------------------------------------------------------------ */
+
+  var tesseractPromise = null;
+
+  function loadTesseract() {
+    if (tesseractPromise) return tesseractPromise;
+    tesseractPromise = new Promise(function (resolve, reject) {
+      if (global.Tesseract) return resolve(global.Tesseract);
+      var s = document.createElement('script');
+      s.src = TESSERACT_CDN;
+      s.async = true;
+      function engineError(message) {
+        var err = new Error(message);
+        err.code = 'ENGINE';
+        return err;
+      }
+      s.onload = function () {
+        if (global.Tesseract) resolve(global.Tesseract);
+        else reject(engineError('Scanner failed to load.'));
+      };
+      s.onerror = function () {
+        tesseractPromise = null; // allow a retry on the next tap
+        reject(engineError('Scanner failed to load. Check your connection.'));
+      };
+      document.head.appendChild(s);
+    });
+    return tesseractPromise;
+  }
+
+  function runOcr(canvas, onProgress) {
+    return loadTesseract().then(function (Tesseract) {
+      var opts = {
+        logger: function (m) {
+          if (m && m.status === 'recognizing text' && typeof m.progress === 'number') {
+            onProgress(m.progress);
+          }
+        },
+      };
+      if (CONFIG.workerPath) opts.workerPath = CONFIG.workerPath;
+      if (CONFIG.corePath) opts.corePath = CONFIG.corePath;
+      if (CONFIG.langPath) opts.langPath = CONFIG.langPath;
+
+      return Tesseract.recognize(canvas, 'eng', opts).then(function (res) {
+        return (res && res.data && res.data.text) || '';
+      });
+    });
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Styles
+   * ------------------------------------------------------------------ */
+
+  var CSS = [
+    '.cdscan{--cdscan-fg:var(--ink-900,#0f2c2a);--cdscan-accent:var(--teal-500,#1f8f7b);',
+    'background:var(--card-bg,#fff);border:var(--card-border,1px solid rgba(15,44,42,.1));',
+    'border-radius:var(--card-radius,16px);box-shadow:var(--shadow-card,0 4px 12px rgba(13,52,82,.1));',
+    'padding:var(--space-5,24px);color:var(--cdscan-fg);font-family:var(--font-ui,system-ui,sans-serif);}',
+
+    '.cdscan__head{display:flex;gap:12px;align-items:flex-start;}',
+    '.cdscan__glyph{flex:0 0 auto;width:40px;height:40px;border-radius:12px;display:grid;place-items:center;',
+    'background:rgba(36,166,135,.14);color:var(--teal-500,#1f8f7b);}',
+    '.cdscan__glyph svg{width:22px;height:22px;}',
+    '.cdscan__title{margin:0;font-size:var(--text-lg,1.1rem);font-weight:800;line-height:1.25;}',
+    '.cdscan__sub{margin:4px 0 0;font-size:var(--text-sm,.85rem);opacity:.8;line-height:1.5;}',
+
+    '.cdscan__actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:16px;}',
+    '.cdscan__btn{appearance:none;border:0;cursor:pointer;font:inherit;font-weight:800;',
+    'border-radius:var(--radius-pill,999px);padding:13px 20px;min-height:48px;display:inline-flex;',
+    'align-items:center;gap:8px;transition:transform .15s var(--ease-out,ease),box-shadow .15s;}',
+    '.cdscan__btn:active{transform:translateY(1px);}',
+    '.cdscan__btn:focus-visible{outline:3px solid var(--cdscan-accent);outline-offset:2px;}',
+    '.cdscan__btn--primary{background:var(--cdscan-accent);color:#fff;box-shadow:0 4px 0 rgba(15,44,42,.28);}',
+    '.cdscan__btn--ghost{background:transparent;color:var(--cdscan-fg);',
+    'box-shadow:inset 0 0 0 2px var(--card-border-color,rgba(15,44,42,.18));}',
+    '.cdscan__file{position:absolute;width:1px;height:1px;opacity:0;pointer-events:none;}',
+
+    '.cdscan__panel{margin-top:16px;}',
+    '.cdscan__panel[hidden]{display:none;}',
+
+    '.cdscan__progress{display:flex;align-items:center;gap:12px;font-size:var(--text-sm,.85rem);font-weight:700;}',
+    '.cdscan__spinner{width:20px;height:20px;border-radius:50%;flex:0 0 auto;',
+    'border:3px solid rgba(36,166,135,.25);border-top-color:var(--cdscan-accent);',
+    'animation:cdscan-spin .8s linear infinite;}',
+    '@keyframes cdscan-spin{to{transform:rotate(360deg);}}',
+    '@media (prefers-reduced-motion:reduce){.cdscan__spinner{animation-duration:2s;}}',
+    '.cdscan__bar{margin-top:10px;height:6px;border-radius:999px;overflow:hidden;',
+    'background:rgba(15,44,42,.1);}',
+    '.cdscan__bar>i{display:block;height:100%;width:0;background:var(--cdscan-accent);',
+    'transition:width .25s var(--ease-out,ease);}',
+
+    '.cdscan__result{border-radius:var(--radius-md,14px);padding:16px;',
+    'border:2px solid rgba(36,166,135,.35);background:rgba(36,166,135,.07);}',
+    '.cdscan__result--warn{border-color:rgba(180,83,9,.45);background:rgba(180,83,9,.08);}',
+    '.cdscan__result--danger{border-color:rgba(139,17,17,.5);background:rgba(139,17,17,.08);}',
+    '.cdscan__eyebrow{font-size:var(--text-2xs,.68rem);font-weight:800;letter-spacing:.08em;',
+    'text-transform:uppercase;opacity:.75;margin:0 0 6px;}',
+    '.cdscan__drug{margin:0;font-size:var(--text-xl,1.35rem);font-weight:900;line-height:1.15;}',
+    '.cdscan__strength{display:inline-block;margin-top:8px;padding:6px 14px;border-radius:999px;',
+    'background:var(--cdscan-accent);color:#fff;font-weight:900;font-size:var(--text-md,1rem);',
+    'font-variant-numeric:tabular-nums;}',
+    '.cdscan__result--warn .cdscan__strength{background:var(--warning,#b45309);}',
+    '.cdscan__result--danger .cdscan__strength{background:var(--danger,#8b1111);}',
+    '.cdscan__meta{margin:10px 0 0;font-size:var(--text-sm,.85rem);opacity:.85;}',
+    '.cdscan__note{margin:12px 0 0;font-size:var(--text-sm,.85rem);line-height:1.55;}',
+
+    '.cdscan__confirm{margin-top:14px;padding-top:14px;border-top:1px dashed var(--card-border-color,rgba(15,44,42,.18));}',
+    '.cdscan__confirm p{margin:0 0 10px;font-weight:800;font-size:var(--text-sm,.9rem);}',
+
+    '.cdscan__list{list-style:none;margin:10px 0 0;padding:0;display:grid;gap:8px;}',
+    '.cdscan__opt{width:100%;text-align:left;appearance:none;cursor:pointer;font:inherit;',
+    'background:var(--surface-subtle,rgba(15,44,42,.04));color:inherit;border:1px solid ',
+    'var(--card-border-color,rgba(15,44,42,.12));border-radius:var(--radius-sm,10px);',
+    'padding:12px 14px;min-height:48px;transition:background .15s;}',
+    '.cdscan__opt:hover{background:var(--surface-hover,rgba(15,44,42,.08));}',
+    '.cdscan__opt:focus-visible{outline:3px solid var(--cdscan-accent);outline-offset:2px;}',
+    '.cdscan__opt b{display:block;font-weight:800;}',
+    '.cdscan__opt span{display:block;font-size:var(--text-xs,.78rem);opacity:.8;margin-top:2px;}',
+
+    '.cdscan__disclaimer{margin:14px 0 0;font-size:var(--text-xs,.78rem);line-height:1.5;opacity:.85;}',
+    '.cdscan__error{margin:0;font-weight:700;color:var(--danger,#8b1111);font-size:var(--text-sm,.9rem);}',
+    '.cdscan__privacy{margin:10px 0 0;font-size:var(--text-2xs,.7rem);opacity:.7;}',
+  ].join('');
+
+  function injectStyles() {
+    if (document.getElementById('cdscan-styles')) return;
+    var el = document.createElement('style');
+    el.id = 'cdscan-styles';
+    el.textContent = CSS;
+    document.head.appendChild(el);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Component
+   * ------------------------------------------------------------------ */
+
+  var DISCLAIMER =
+    'Always confirm dosing before administering medication. This scan identifies the bottle — it does not replace reading the label.';
+
+  /* Lucide "camera" — the house icon set. No emoji in product UI. */
+  var CAMERA_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" ' +
+    'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' +
+    '<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3Z"/>' +
+    '<circle cx="12" cy="13" r="3.5"/></svg>';
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  function byId(id) {
+    for (var i = 0; i < PRODUCTS.length; i++) {
+      if (PRODUCTS[i].id === id) return PRODUCTS[i];
+    }
+    return null;
+  }
+
+  function track(name, params) {
+    try {
+      if (typeof global.gtag === 'function') global.gtag('event', name, params || {});
+    } catch (e) { /* analytics must never break the scanner */ }
+  }
+
+  function create(host) {
+    injectStyles();
+
+    host.classList.add('cdscan');
+    host.innerHTML = [
+      '<div class="cdscan__head">',
+      '<span class="cdscan__glyph" aria-hidden="true">' + CAMERA_ICON + '</span>',
+      '<div>',
+      '<h2 class="cdscan__title">Not sure what you’re holding?</h2>',
+      '<p class="cdscan__sub">Take a photo of the front of the bottle. We’ll tell you which medicine it is and how strong it is, so you know which number to use.</p>',
+      '</div>',
+      '</div>',
+      '<div class="cdscan__actions">',
+      '<button type="button" class="cdscan__btn cdscan__btn--primary" data-scan>Scan the bottle</button>',
+      '<button type="button" class="cdscan__btn cdscan__btn--ghost" data-manual>Pick it from a list</button>',
+      '</div>',
+      '<input type="file" accept="image/*" capture="environment" class="cdscan__file" data-file aria-hidden="true" tabindex="-1" />',
+      '<div class="cdscan__panel" data-panel hidden aria-live="polite"></div>',
+      '<p class="cdscan__privacy">The photo is read on your phone and never leaves it.</p>',
+    ].join('');
+
+    var panel = host.querySelector('[data-panel]');
+    var fileInput = host.querySelector('[data-file]');
+
+    function show(html) {
+      panel.hidden = false;
+      panel.innerHTML = html;
+    }
+
+    function renderProgress(pct) {
+      show(
+        [
+          '<div class="cdscan__progress"><span class="cdscan__spinner" aria-hidden="true"></span>',
+          '<span>Reading the label…</span></div>',
+          '<div class="cdscan__bar"><i style="width:' + Math.round(pct * 100) + '%"></i></div>',
+        ].join('')
+      );
+    }
+
+    function renderManual(heading) {
+      var items = MANUAL_ORDER.map(function (id) {
+        var p = byId(id);
+        return [
+          '<li><button type="button" class="cdscan__opt" data-pick="' + p.id + '">',
+          '<b>' + esc(p.drug) + ' — ' + esc(p.strength) + '</b>',
+          '<span>' + esc(p.brand) + ' · ' + esc(p.form) + '</span>',
+          '</button></li>',
+        ].join('');
+      }).join('');
+
+      show(
+        [
+          '<p class="cdscan__eyebrow">' + esc(heading || 'Choose your bottle') + '</p>',
+          '<ul class="cdscan__list">' + items + '</ul>',
+          '<p class="cdscan__disclaimer">' + DISCLAIMER + '</p>',
+        ].join('')
+      );
+    }
+
+    function renderProduct(product, opts) {
+      opts = opts || {};
+      var toneClass =
+        product.tone === 'danger'
+          ? ' cdscan__result--danger'
+          : product.tone === 'warn'
+          ? ' cdscan__result--warn'
+          : '';
+
+      var eyebrow = opts.confirmed
+        ? 'Confirmed'
+        : opts.uncertain
+        ? 'Best guess — please check'
+        : 'This looks like';
+
+      var html = [
+        '<div class="cdscan__result' + toneClass + '">',
+        '<p class="cdscan__eyebrow">' + esc(eyebrow) + '</p>',
+        '<h3 class="cdscan__drug">' + esc(product.drug) + '</h3>',
+        '<span class="cdscan__strength">' + esc(product.strength) + '</span>',
+        '<p class="cdscan__meta">' + esc(product.brand) + ' · ' + esc(product.form) + '</p>',
+        '<p class="cdscan__note">' + esc(product.calcNote) + '</p>',
+      ];
+
+      if (!opts.confirmed) {
+        html.push(
+          '<div class="cdscan__confirm">',
+          '<p>Does that match the bottle in your hand?</p>',
+          '<div class="cdscan__actions" style="margin-top:0">',
+          '<button type="button" class="cdscan__btn cdscan__btn--primary" data-confirm="' +
+            product.id +
+            '">Yes, that’s it</button>',
+          '<button type="button" class="cdscan__btn cdscan__btn--ghost" data-manual>No — show the list</button>',
+          '</div>',
+          '</div>'
+        );
+      } else {
+        html.push(
+          '<div class="cdscan__confirm">',
+          '<div class="cdscan__actions" style="margin-top:0">',
+          '<button type="button" class="cdscan__btn cdscan__btn--primary" data-gocalc>Go to the calculator</button>',
+          '<button type="button" class="cdscan__btn cdscan__btn--ghost" data-scan>Scan another bottle</button>',
+          '</div>',
+          '</div>'
+        );
+      }
+
+      html.push('</div>');
+      html.push('<p class="cdscan__disclaimer">' + DISCLAIMER + '</p>');
+      show(html.join(''));
+    }
+
+    function renderFailure(message) {
+      show(
+        [
+          '<div class="cdscan__result cdscan__result--warn">',
+          '<p class="cdscan__eyebrow">Couldn’t read that one</p>',
+          '<p class="cdscan__error">' + esc(message) + '</p>',
+          '<p class="cdscan__note">Labels are shiny and cameras are not always kind at 3am. Try filling the frame with the front of the label in good light — or just pick your bottle from the list below.</p>',
+          '<div class="cdscan__actions" style="margin-top:12px">',
+          '<button type="button" class="cdscan__btn cdscan__btn--primary" data-scan>Try another photo</button>',
+          '<button type="button" class="cdscan__btn cdscan__btn--ghost" data-manual>Pick it from a list</button>',
+          '</div>',
+          '</div>',
+        ].join('')
+      );
+    }
+
+    function handleFile(file) {
+      if (!file) return;
+      renderProgress(0.02);
+      track('label_scan_start');
+
+      preprocess(file)
+        .then(function (out) {
+          renderProgress(0.1);
+          return runOcr(out.canvas, function (p) {
+            renderProgress(0.1 + p * 0.9);
+          });
+        })
+        .then(function (text) {
+          var res = identify(text);
+
+          if (!res.best) {
+            if (res.ingredients.length === 1) {
+              // We know the drug but not the strength — that is still useful,
+              // but the strength is the dangerous half, so go to the list
+              // filtered by what we did read.
+              track('label_scan_partial', { ingredient: res.ingredients[0] });
+              renderManual(
+                'We read "' +
+                  res.ingredients[0] +
+                  '" but not the strength — pick your bottle'
+              );
+              return;
+            }
+            track('label_scan_fail');
+            renderFailure('We couldn’t make out the medicine name or the strength.');
+            return;
+          }
+
+          track('label_scan_match', { product: res.best.id, score: res.score });
+          renderProduct(res.best, { uncertain: res.ambiguous || res.score < 6 });
+        })
+        .catch(function (err) {
+          // If the OCR engine itself couldn't load (offline, CDN blocked),
+          // there is no point offering "try another photo" — send them
+          // straight to the list, which always works.
+          if (err && err.code === 'ENGINE') {
+            track('label_scan_engine_unavailable');
+            renderManual('Scanner is offline — pick your bottle instead');
+            return;
+          }
+          track('label_scan_error');
+          renderFailure(
+            (err && err.message) || 'Something went wrong reading that photo.'
+          );
+        });
+    }
+
+    fileInput.addEventListener('change', function () {
+      var file = fileInput.files && fileInput.files[0];
+      fileInput.value = ''; // allow re-picking the same file
+      handleFile(file);
+    });
+
+    host.addEventListener('click', function (ev) {
+      var t = ev.target.closest('[data-scan],[data-manual],[data-pick],[data-confirm],[data-gocalc]');
+      if (!t || !host.contains(t)) return;
+
+      if (t.hasAttribute('data-scan')) {
+        fileInput.click();
+        return;
+      }
+      if (t.hasAttribute('data-manual')) {
+        track('label_scan_manual_open');
+        renderManual('Choose your bottle');
+        return;
+      }
+      if (t.hasAttribute('data-pick')) {
+        var picked = byId(t.getAttribute('data-pick'));
+        if (picked) {
+          track('label_scan_manual_pick', { product: picked.id });
+          renderProduct(picked, { confirmed: true });
+        }
+        return;
+      }
+      if (t.hasAttribute('data-confirm')) {
+        var confirmed = byId(t.getAttribute('data-confirm'));
+        if (confirmed) {
+          track('label_scan_confirmed', { product: confirmed.id });
+          renderProduct(confirmed, { confirmed: true });
+        }
+        return;
+      }
+      if (t.hasAttribute('data-gocalc')) {
+        var calc = document.getElementById('calculator-card') ||
+          document.querySelector('[data-calculator-root]');
+        if (calc) {
+          calc.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          var input = calc.querySelector('input[type="number"],input[inputmode="decimal"]');
+          if (input) setTimeout(function () { input.focus(); }, 450);
+        }
+      }
+    });
+
+    return { host: host, identify: identify };
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Auto-mount
+   * ------------------------------------------------------------------ */
+
+  function autoMount() {
+    var explicit = document.querySelector('[data-label-scanner]');
+    if (explicit) return create(explicit);
+
+    // Fall back to inserting directly above the calculator card so the page
+    // works with no markup change.
+    var calc =
+      document.getElementById('calculator-card') ||
+      document.querySelector('[data-calculator-root]');
+    if (!calc || !calc.parentNode) return null;
+
+    var section = document.createElement('section');
+    section.setAttribute('data-label-scanner', '');
+    section.setAttribute('aria-label', 'Identify your medicine bottle');
+    section.style.marginBottom = 'var(--space-4, 16px)';
+    calc.parentNode.insertBefore(section, calc);
+    return create(section);
+  }
+
+  global.CloseDoseLabelScanner = {
+    mount: create,
+    identify: identify,
+    normalise: normalise,
+    products: PRODUCTS,
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoMount);
+  } else {
+    autoMount();
+  }
+})(window);


### PR DESCRIPTION
## **User description**
## Summary

Three additions aimed at the same moment: a tired caregiver holding a bottle at 3am, unsure what they've got.

- **Bottle-label scanner** — photograph the front of the bottle, get back the medicine and its concentration. On-device OCR, no backend.
- **Add to Home Screen** — native installer on Android, real Safari instructions on iOS.
- **Share** — `navigator.share` with a clipboard fallback, in the header and menu.

Both new modules are self-contained. They inject their own CSS built from the existing `global.css` custom properties, so they inherit light/dark mode and the accessibility settings for free. No build step, no repo dependencies added.

| File | Scope |
| --- | --- |
| `public/widget/label-scanner.js` (new) | `index.html` only |
| `public/pwa.js` (new) | all 7 caregiver-facing pages |
| 7 HTML pages | script tags + `apple-mobile-web-app-*` meta |

## Bottle-label scanner

Answers the two questions that actually cause dosing errors: **which medicine** and **how strong**.

- `<input type="file" capture="environment">` opens the native camera — far more reliable across iOS/Android than `getUserMedia`.
- The image is downscaled to 1600px, greyscaled, and histogram contrast-stretched on a canvas before OCR. Roughly halves read time and materially improves accuracy on glossy curved labels.
- OCR is Tesseract.js 5.1.1, **lazy-loaded from jsDelivr on first tap** — page weight is unchanged for anyone who never uses the feature.
- The photo never leaves the device and is released as soon as the read finishes.

### Safety posture — please don't weaken this in review

1. **OCR output is a suggestion, never truth.** Every result is shown back with "Does that match the bottle in your hand?" before it can be used for anything.
2. **The scanner identifies a product; it never calculates a dose.** Dose math stays in the calculator, which requires a weight.
3. **Failure is loud, not silent.** An unreadable photo, a near-tie between two strengths of the same drug, or an unavailable OCR engine all fall through to the manual picker. Guessing is worse than asking.
4. The mandatory disclaimer renders on every result state, verbatim.

### Products recognised

Nine US OTC products. Two are flagged deliberately, because they're the ones that cause real-world errors:

- **Acetaminophen 80 mg / 0.8 mL** — the concentrated infant drops discontinued in the US in 2011. Danger tone, with an explicit "do not use a dose calculated for 160 mg / 5 mL with this bottle."
- **Ibuprofen 50 mg / 1.25 mL** — infant drops, easily confused with the 100 mg / 5 mL children's liquid. Warning tone.

Adult tablets (325/500 mg APAP, 200 mg ibuprofen) are recognised and warned against rather than silently ignored, since a parent may well be holding one.

### Self-hosting the OCR engine

The jsDelivr dependency degrades gracefully — CDN unreachable falls back to the manual picker. To remove it, set before the script tag:

```js
window.CLOSEDOSE_SCANNER_CONFIG = {
  scriptUrl:  '/vendor/tess/tesseract.min.js',
  workerPath: '/vendor/tess/worker.min.js',
  corePath:   '/vendor/tess/',
  langPath:   '/vendor/tess/'
};
```

Costs roughly 15 MB of assets in `public/`.

## Add to Home Screen

- **Android/Chrome** — captures `beforeinstallprompt`, drives the native installer.
- **iOS Safari** — no such event exists, so it shows the three manual steps with the real iOS share glyph and the exact wording iOS uses ("Add to Home Screen").
- Waits 25s before appearing, so it never interrupts a first visit.
- Dismissal remembered 60 days. Tapping the install CTA also snoozes, so backing out of the native sheet doesn't cause re-nagging.
- Suppressed entirely when already running standalone.

**Worth flagging:** `apple-mobile-web-app-capable` was absent from every page before this change, which means iOS installs would have opened with browser chrome rather than standalone. Added to all 7 pages.

## Share

`navigator.share` where available, clipboard copy with a confirmation toast otherwise. Buttons injected into the site header and the menu panel. Any element marked `data-share-closedose` is also wired up, for placing an inline share CTA later.

`public/share/` is an unrelated existing feature (shared dosing card) — no conflict.

## Deliberately not done

**No service worker.** Offline caching on a dosing tool means a caregiver could be shown stale dose data after a correction has shipped. That risk outweighs the offline benefit here, and Add to Home Screen works fine without one. Happy to revisit if you'd rather have offline with an aggressive revalidation strategy.

## Test plan

69 tests, all passing.

**Matcher unit tests (19)** — clean labels; heavy OCR noise (`l6O mg`, `1OO mg per 5 m L`); generic store brands; no-space formats (`100mg/5mL`); negative cases (Benadryl, Zyrtec, garbage text, empty string) that must return `null`; and a forced-ambiguity case that must refuse to answer confidently.

**Browser tests (28)** — render, tap targets ≥44px, manual picker, warning/danger tones, share via both paths, A2HS on Android and iOS, snooze behaviour, dark mode, console errors.

**Full-pipeline OCR (7)** — real Tesseract against generated Tylenol, Motrin, and infant Advil labels. Correct drug *and* concentration on all three, 1.8–3.0s each. A non-label photo correctly falls back instead of guessing.

**Post-integration against real `public/` files (15)** — confirms the existing calculator widget is unaffected, the scanner appears only on `index.html`, and share appears on the other pages without it.

Repo CI passes locally: `sync-parent-tools --check`, `parent-tools`, `i18n`, `voice`.

### Manual check worth doing before merge

Scan a few **real bottles** in real lighting. The synthetic labels are clean flat text; a glossy curved label under a nightlight is the actual hard case. The manual picker is always one tap away if OCR struggles, so the floor is safe — but it's worth knowing the real-world hit rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdgViBdbr1d11LVgM5kUec


___

## **CodeAnt-AI Description**
Help caregivers identify medicine bottles and access CloseDose quickly when dosing matters

### What Changed
- Caregivers can photograph a bottle label to identify acetaminophen or ibuprofen and its strength, with on-device reading and a manual selection fallback when the label cannot be read.
- Scan results require visual confirmation before caregivers continue to the calculator, and warn about concentrated, discontinued, or adult products.
- Ibuprofen results now show both 100 mg / 5 mL and 50 mg / 1.25 mL dose options side by side, so caregivers can match the bottle before measuring.
- Dose volumes are displayed in larger, high-contrast highlighted chips, including in dark mode.
- Share controls are available in the header and menu, using the device share sheet or copying the link when sharing is unavailable.
- Caregivers receive a delayed Add to Home Screen invitation, with native Android installation and step-by-step Safari instructions on iOS. Dismissals are remembered for 60 days.

### Impact
`✅ Fewer concentration mix-ups`
`✅ Clearer dose volumes in dark mode`
`✅ Faster access to bottle identification and sharing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
